### PR TITLE
feat/009 rides payment communication

### DIFF
--- a/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/payment/PassengerPaymentRequestDto.java
+++ b/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/payment/PassengerPaymentRequestDto.java
@@ -1,0 +1,16 @@
+package by.arvisit.cabapp.common.dto.payment;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record PassengerPaymentRequestDto(
+        String rideId,
+        String passengerId,
+        String driverId,
+        BigDecimal amount,
+        String paymentMethod,
+        String cardNumber) {
+    
+}

--- a/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/payment/PassengerPaymentResponseDto.java
+++ b/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/payment/PassengerPaymentResponseDto.java
@@ -1,0 +1,21 @@
+package by.arvisit.cabapp.common.dto.payment;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record PassengerPaymentResponseDto(
+        String id,
+        String rideId,
+        String passengerId,
+        String driverId,
+        BigDecimal amount,
+        BigDecimal feeAmount,
+        String paymentMethod,
+        String status,
+        String cardNumber,
+        ZonedDateTime timestamp) {
+
+}

--- a/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/rides/RideResponseDto.java
+++ b/cab-app-common/src/main/java/by/arvisit/cabapp/common/dto/rides/RideResponseDto.java
@@ -1,0 +1,30 @@
+package by.arvisit.cabapp.common.dto.rides;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record RideResponseDto(
+        String id,
+        BigDecimal initialCost,
+        BigDecimal finalCost,
+        String passengerId,
+        String driverId,
+        String promoCode,
+        String status,
+        String paymentMethod,
+        Boolean isPaid,
+        String startAddress,
+        String destinationAddress,
+        Integer passengerScore,
+        Integer driverScore,
+        ZonedDateTime bookRide,
+        ZonedDateTime cancelRide,
+        ZonedDateTime acceptRide,
+        ZonedDateTime beginRide,
+        ZonedDateTime endRide,
+        ZonedDateTime finishRide) {
+
+}

--- a/cab-app-payment-service/pom.xml
+++ b/cab-app-payment-service/pom.xml
@@ -69,6 +69,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectRideClient.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectRideClient.java
@@ -1,0 +1,17 @@
+package by.arvisit.cabapp.paymentservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
+
+@FeignClient(name = "cab-app-rides-service", url = "${spring.settings.cab-app-rides-service.uri}",
+        configuration = CabAppFeignClientConfiguration.class)
+public interface DirectRideClient extends RideClient {
+
+    @Override
+    @GetMapping("/{id}")
+    RideResponseDto getRideById(@PathVariable String id);
+
+}

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/RideClient.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/RideClient.java
@@ -1,0 +1,9 @@
+package by.arvisit.cabapp.paymentservice.client;
+
+import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
+
+public interface RideClient {
+
+    RideResponseDto getRideById(String id);
+
+}

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/messaging/MessagingConfiguration.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/messaging/MessagingConfiguration.java
@@ -1,0 +1,27 @@
+package by.arvisit.cabapp.paymentservice.messaging;
+
+import java.util.function.Consumer;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.service.PassengerPaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MessagingConfiguration {
+
+    private final PassengerPaymentService passengerPaymentService;
+
+    @Bean
+    Consumer<PassengerPaymentRequestDto> createPayment() {
+        return request -> {
+            log.info("Consumer received request for payment: {}", request);
+            passengerPaymentService.save(request);
+        };
+    }
+}

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImpl.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImpl.java
@@ -7,8 +7,11 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Pageable;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,7 @@ import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
 import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
 import by.arvisit.cabapp.paymentservice.mapper.PassengerPaymentMapper;
 import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
+import by.arvisit.cabapp.paymentservice.persistence.model.PaymentMethodEnum;
 import by.arvisit.cabapp.paymentservice.persistence.model.PaymentStatusEnum;
 import by.arvisit.cabapp.paymentservice.persistence.repository.PassengerPaymentRepository;
 import by.arvisit.cabapp.paymentservice.service.PassengerPaymentService;
@@ -37,6 +41,7 @@ public class PassengerPaymentServiceImpl implements PassengerPaymentService {
     private final PassengerPaymentMapper passengerPaymentMapper;
     private final MessageSource messageSource;
     private final PassengerPaymentVerifier passengerPaymentVerifier;
+    private final StreamBridge streamBridge;
 
     @Transactional
     @Override
@@ -54,8 +59,15 @@ public class PassengerPaymentServiceImpl implements PassengerPaymentService {
         newPayment.setTimestamp(ZonedDateTime.now(CommonConstants.EUROPE_MINSK_TIMEZONE));
         newPayment.setStatus(PaymentStatusEnum.SUCCESS);
 
-        return passengerPaymentMapper.fromEntityToResponseDto(
+        PassengerPaymentResponseDto paymentToSend = passengerPaymentMapper.fromEntityToResponseDto(
                 passengerPaymentRepository.save(newPayment));
+
+        if (newPayment.getPaymentMethod() == PaymentMethodEnum.BANK_CARD) {
+            Message<PassengerPaymentResponseDto> message = MessageBuilder.withPayload(paymentToSend).build();
+            streamBridge.send("outPayment", message); // TODO channel to constants, and change its name
+        }
+
+        return paymentToSend;
     }
 
     @Transactional(readOnly = true)

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImpl.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImpl.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PassengerPaymentServiceImpl implements PassengerPaymentService {
 
+    private static final String OUT_CARD_PAYMENT_CREATED_CHANNEL = "outCardPaymentCreated";
     private static final String FOUND_NO_ENTITY_BY_ID_MESSAGE_TEMPLATE_KEY = "by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.id.EntityNotFoundException.template";
 
     private final PassengerPaymentRepository passengerPaymentRepository;
@@ -64,7 +65,7 @@ public class PassengerPaymentServiceImpl implements PassengerPaymentService {
 
         if (newPayment.getPaymentMethod() == PaymentMethodEnum.BANK_CARD) {
             Message<PassengerPaymentResponseDto> message = MessageBuilder.withPayload(paymentToSend).build();
-            streamBridge.send("outPayment", message); // TODO channel to constants, and change its name
+            streamBridge.send(OUT_CARD_PAYMENT_CREATED_CHANNEL, message);
         }
 
         return paymentToSend;

--- a/cab-app-payment-service/src/main/resources/application-dev.yml
+++ b/cab-app-payment-service/src/main/resources/application-dev.yml
@@ -11,6 +11,21 @@ spring:
     cab-app-rides-service:
       uri: http://localhost:${RIDES_SERVICE_PORT}/api/v1/rides
 
+  cloud:
+    stream:
+      function:
+        definition: createPayment
+      bindings:
+        createPayment-in-0:
+          destination: passengerPayCardTopic
+          content-type: application/json
+        outPayment:
+          destination: confirmPayCardTopic
+          content-type: application/json
+      kafka:
+        binder:
+          brokers: localhost:29092
+
 logging:
   level:
     '[by.arvisit.cabapp]': debug

--- a/cab-app-payment-service/src/main/resources/application-dev.yml
+++ b/cab-app-payment-service/src/main/resources/application-dev.yml
@@ -8,6 +8,8 @@ spring:
       uri: http://localhost:${PASSENGER_SERVICE_PORT}/api/v1/passengers
     cab-app-driver-service:
       uri: http://localhost:${DRIVER_SERVICE_PORT}/api/v1/drivers
+    cab-app-rides-service:
+      uri: http://localhost:${RIDES_SERVICE_PORT}/api/v1/rides
 
 logging:
   level:

--- a/cab-app-payment-service/src/main/resources/application-dev.yml
+++ b/cab-app-payment-service/src/main/resources/application-dev.yml
@@ -11,21 +11,6 @@ spring:
     cab-app-rides-service:
       uri: http://localhost:${RIDES_SERVICE_PORT}/api/v1/rides
 
-  cloud:
-    stream:
-      function:
-        definition: createPayment
-      bindings:
-        createPayment-in-0:
-          destination: passengerPayCardTopic
-          content-type: application/json
-        outPayment:
-          destination: confirmPayCardTopic
-          content-type: application/json
-      kafka:
-        binder:
-          brokers: localhost:29092
-
 logging:
   level:
     '[by.arvisit.cabapp]': debug

--- a/cab-app-payment-service/src/main/resources/application.yml
+++ b/cab-app-payment-service/src/main/resources/application.yml
@@ -17,9 +17,9 @@ spring:
         max-page-size: 50
   
   cloud:
+    function:
+      definition: createPayment
     stream:
-      function:
-        definition: createPayment
       bindings:
         createPayment-in-0:
           destination: passengerPayCardTopic

--- a/cab-app-payment-service/src/main/resources/application.yml
+++ b/cab-app-payment-service/src/main/resources/application.yml
@@ -15,6 +15,22 @@ spring:
     web:
       pageable:
         max-page-size: 50
+  
+  cloud:
+    stream:
+      function:
+        definition: createPayment
+      bindings:
+        createPayment-in-0:
+          destination: passengerPayCardTopic
+          content-type: application/json
+          group: passengerPayCardCreating
+        outCardPaymentCreated:
+          destination: cardPaymentCreatedTopic
+          content-type: application/json
+      kafka:
+        binder:
+          brokers: localhost:29092
 
 logging:
   level:

--- a/cab-app-payment-service/src/main/resources/messages.properties
+++ b/cab-app-payment-service/src/main/resources/messages.properties
@@ -2,6 +2,7 @@ by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.rideId.passe
 by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.rideId.passengerId.driverId.status.IllegalStateException.template=Payment for the ride with id {0} was already successfully made
 by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.id.EntityNotFoundException.template=Found no payment with id {0}
 by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.cardNumber.IllegalStateException.template=The payment card number does not match the one associated with this passenger
+by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment.details.IllegalStateException.template=Payment ride details does not match with the actual ride
 
 by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment.id.EntityNotFoundException.template=Found no payment with id {0}
 by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment.balance.IllegalStateException.template=Low balance to perform operation

--- a/cab-app-rides-service/pom.xml
+++ b/cab-app-rides-service/pom.xml
@@ -69,6 +69,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/client/DirectPaymentClient.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/client/DirectPaymentClient.java
@@ -1,0 +1,18 @@
+package by.arvisit.cabapp.ridesservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentResponseDto;
+
+@FeignClient(name = "cab-app-payment-service", url = "${spring.settings.cab-app-payment-service.uri}",
+        configuration = CabAppFeignClientConfiguration.class)
+public interface DirectPaymentClient extends PaymentClient {
+
+    @Override
+    @PostMapping
+    PassengerPaymentResponseDto save(@RequestBody PassengerPaymentRequestDto dto);
+
+}

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/client/PaymentClient.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/client/PaymentClient.java
@@ -1,0 +1,9 @@
+package by.arvisit.cabapp.ridesservice.client;
+
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentResponseDto;
+
+public interface PaymentClient {
+
+    PassengerPaymentResponseDto save(PassengerPaymentRequestDto dto);
+}

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/dto/RideResponseDto.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/dto/RideResponseDto.java
@@ -1,5 +1,6 @@
 package by.arvisit.cabapp.ridesservice.dto;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 
 import lombok.Builder;
@@ -7,8 +8,8 @@ import lombok.Builder;
 @Builder(setterPrefix = "with")
 public record RideResponseDto(
         String id,
-        String initialCost,
-        String finalCost,
+        BigDecimal initialCost,
+        BigDecimal finalCost,
         String passengerId,
         String driverId,
         String promoCode,

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/mapper/RideMapper.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/mapper/RideMapper.java
@@ -38,4 +38,8 @@ public interface RideMapper {
     @Mapping(target = "amount", source = "finalCost")
     @Mapping(target = "cardNumber", ignore = true)
     PassengerPaymentRequestDto fromRideToPassengerPaymentRequestDto(Ride entity);
+
+    @Mapping(target = "rideId", source = "entity.id")
+    @Mapping(target = "amount", source = "entity.finalCost")
+    PassengerPaymentRequestDto fromRideToPassengerPaymentRequestDto(Ride entity, String cardNumber);
 }

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/mapper/RideMapper.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/mapper/RideMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentRequestDto;
 import by.arvisit.cabapp.ridesservice.dto.RideRequestDto;
 import by.arvisit.cabapp.ridesservice.dto.RideResponseDto;
 import by.arvisit.cabapp.ridesservice.persistence.model.Ride;
@@ -32,4 +33,9 @@ public interface RideMapper {
     @Mapping(target = "promoCode",
             expression = "java(entity.getPromoCode() != null ? entity.getPromoCode().getKeyword() : null)")
     RideResponseDto fromEntityToResponseDto(Ride entity);
+
+    @Mapping(target = "rideId", source = "id")
+    @Mapping(target = "amount", source = "finalCost")
+    @Mapping(target = "cardNumber", ignore = true)
+    PassengerPaymentRequestDto fromRideToPassengerPaymentRequestDto(Ride entity);
 }

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/messaging/MessagingConfiguration.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/messaging/MessagingConfiguration.java
@@ -1,0 +1,41 @@
+package by.arvisit.cabapp.ridesservice.messaging;
+
+import java.util.function.Consumer;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.ridesservice.service.RideService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MessagingConfiguration {
+
+    private static final String SUCCESS_STATUS = "SUCCESS";
+    private static final String PAYMENT_NOT_SUCCESS_STATUS_MESSAGE_TEMPLATE = "by.arvisit.cabapp.ridesservice.persistence.model.Ride.isPaid.IllegalStateException.template";
+    private final MessageSource messageSource; // TODO messageSource and success status are duplicates from
+                                               // RideServiceImpl
+                                               // should be extracted to some verification class
+    private final RideService rideService;
+
+    @Bean
+    Consumer<PassengerPaymentResponseDto> confirmCardPayment() {
+        return response -> {
+            log.info("Consumer received response for card payment: {}", response);
+
+            if (!SUCCESS_STATUS.equals(response.status())) {
+                String errorMessage = messageSource.getMessage(
+                        PAYMENT_NOT_SUCCESS_STATUS_MESSAGE_TEMPLATE,
+                        new Object[] {}, null);
+                throw new IllegalStateException(errorMessage);
+            }
+
+            rideService.confirmPayment(response.rideId());
+        };
+    }
+}

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/service/impl/RideServiceImpl.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/service/impl/RideServiceImpl.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RideServiceImpl implements RideService {
 
+    private static final String OUT_CREATE_CARD_PAYMENT_CHANNEL = "outCreateCardPayment";
     private static final String PAYMENT_NOT_SUCCESS_STATUS_MESSAGE_TEMPLATE = "by.arvisit.cabapp.ridesservice.persistence.model.Ride.isPaid.IllegalStateException.template";
     private static final String SUCCESS_STATUS = "SUCCESS";
     private static final String FOUND_NO_ENTITY_BY_ID_MESSAGE_TEMPLATE_KEY = "by.arvisit.cabapp.ridesservice.persistence.model.Ride.id.EntityNotFoundException.template";
@@ -171,7 +172,7 @@ public class RideServiceImpl implements RideService {
                     passenger.cardNumber());
 
             Message<PassengerPaymentRequestDto> message = MessageBuilder.withPayload(payment).build();
-            streamBridge.send("outPayment", message); // TODO topic to constants
+            streamBridge.send(OUT_CREATE_CARD_PAYMENT_CHANNEL, message);
         }
 
         return rideMapper.fromEntityToResponseDto(

--- a/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/util/PaymentVerifier.java
+++ b/cab-app-rides-service/src/main/java/by/arvisit/cabapp/ridesservice/util/PaymentVerifier.java
@@ -1,0 +1,26 @@
+package by.arvisit.cabapp.ridesservice.util;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+
+import by.arvisit.cabapp.common.dto.payment.PassengerPaymentResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentVerifier {
+    private static final String SUCCESS_STATUS = "SUCCESS";
+    private static final String PAYMENT_NOT_SUCCESS_STATUS_MESSAGE_TEMPLATE = "by.arvisit.cabapp.ridesservice.persistence.model.Ride.isPaid.IllegalStateException.template";
+    private final MessageSource messageSource;
+
+    public void verifyPaymentStatus(PassengerPaymentResponseDto payment) {
+        if (!SUCCESS_STATUS.equals(payment.status())) {
+
+            String errorMessage = messageSource.getMessage(
+                    PAYMENT_NOT_SUCCESS_STATUS_MESSAGE_TEMPLATE,
+                    new Object[] {}, null);
+            throw new IllegalStateException(errorMessage);
+        }
+    }
+
+}

--- a/cab-app-rides-service/src/main/resources/application-dev.yml
+++ b/cab-app-rides-service/src/main/resources/application-dev.yml
@@ -10,20 +10,6 @@ spring:
       uri: http://localhost:${DRIVER_SERVICE_PORT}/api/v1/drivers
     cab-app-payment-service:
       uri: http://localhost:${PAYMENT_SERVICE_PORT}/api/v1/passenger-payments
-  cloud:
-    stream:
-      function:
-        definition: confirmCardPayment
-      bindings:
-        outPayment:
-          destination: passengerPayCardTopic
-          content-type: application/json
-        confirmCardPayment-in-0:
-          destination: confirmPayCardTopic
-          content-type: application/json
-      kafka:
-        binder:
-          brokers: localhost:29092
 
 logging:
   level:

--- a/cab-app-rides-service/src/main/resources/application-dev.yml
+++ b/cab-app-rides-service/src/main/resources/application-dev.yml
@@ -10,6 +10,20 @@ spring:
       uri: http://localhost:${DRIVER_SERVICE_PORT}/api/v1/drivers
     cab-app-payment-service:
       uri: http://localhost:${PAYMENT_SERVICE_PORT}/api/v1/passenger-payments
+  cloud:
+    stream:
+      function:
+        definition: confirmCardPayment
+      bindings:
+        outPayment:
+          destination: passengerPayCardTopic
+          content-type: application/json
+        confirmCardPayment-in-0:
+          destination: confirmPayCardTopic
+          content-type: application/json
+      kafka:
+        binder:
+          brokers: localhost:29092
 
 logging:
   level:

--- a/cab-app-rides-service/src/main/resources/application-dev.yml
+++ b/cab-app-rides-service/src/main/resources/application-dev.yml
@@ -8,6 +8,8 @@ spring:
       uri: http://localhost:${PASSENGER_SERVICE_PORT}/api/v1/passengers
     cab-app-driver-service:
       uri: http://localhost:${DRIVER_SERVICE_PORT}/api/v1/drivers
+    cab-app-payment-service:
+      uri: http://localhost:${PAYMENT_SERVICE_PORT}/api/v1/passenger-payments
 
 logging:
   level:

--- a/cab-app-rides-service/src/main/resources/application.yml
+++ b/cab-app-rides-service/src/main/resources/application.yml
@@ -16,6 +16,22 @@ spring:
       pageable:
         max-page-size: 50
 
+  cloud:
+    stream:
+      function:
+        definition: confirmCardPayment
+      bindings:
+        outCreateCardPayment:
+          destination: passengerPayCardTopic
+          content-type: application/json
+        confirmCardPayment-in-0:
+          destination: cardPaymentCreatedTopic
+          content-type: application/json
+          group: cardPaymentConfirming
+      kafka:
+        binder:
+          brokers: localhost:29092
+
 logging:
   level:
     root: info

--- a/cab-app-rides-service/src/main/resources/application.yml
+++ b/cab-app-rides-service/src/main/resources/application.yml
@@ -17,9 +17,9 @@ spring:
         max-page-size: 50
 
   cloud:
+    function:
+      definition: confirmCardPayment
     stream:
-      function:
-        definition: confirmCardPayment
       bindings:
         outCreateCardPayment:
           destination: passengerPayCardTopic

--- a/cab-app-rides-service/src/main/resources/messages.properties
+++ b/cab-app-rides-service/src/main/resources/messages.properties
@@ -36,5 +36,6 @@ by.arvisit.cabapp.ridesservice.persistence.model.Ride.passengerScore.IllegalStat
 
 by.arvisit.cabapp.ridesservice.persistence.model.Ride.driverScore.EntityNotFoundException.template=Found no scores for driver with id {0}
 by.arvisit.cabapp.ridesservice.persistence.model.Ride.passengerScore.EntityNotFoundException.template=Found no scores for passenger with id {0}
+by.arvisit.cabapp.ridesservice.persistence.model.Ride.isPaid.IllegalStateException.template=Payment has not gotten SUCCESS status for some reason
 
 by.arvisit.cabapp.ridesservice.validation.MapContainsKey.message=Patch should contain key: {value}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.4
+    ports:
+      - 22181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=stat"
+    healthcheck:
+      test: "echo stat | nc localhost 2181 | grep Mode"
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cab_app_net
+
+  kafkaserver:
+    image: confluentinc/cp-kafka:7.4.4
+    ports:
+      - 29092:29092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafkaserver:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    networks:
+      - cab_app_net
+      
+networks:
+  cab_app_net:


### PR DESCRIPTION
- **Use BigDecimal instead of String for cost fields**
- **Add ride response dto to common lib**
- **Add feign client for rides service**
- **Add ride verification for passenger payment**
- **Add passenger payment dtos to common lib**
- **Add feign client for payment service**
- **Add method to map from ride to payment request dto**
- **Save payment after cash payment confirmation**
- **Add docker compose for kafka + zookeeper**
- **Add dependecies for message brokers usage to payment, rides services**
- **Add mapper method to request for payment with card**
- **Configure message consumer for card payment response**
- **Add message request to create card payment**
- **Specify properties for in, out message streams**
- **Configure card payment message request processing**
- **Send message about card payment processing**
- **Specify properties for message broker**
- **Rename channels for kafka**
- **Extract payment verification to separate class**
- **Correct function.definition for payment and rides services**
