### PR TITLE
test/015 unit tests driver service

### DIFF
--- a/cab-app-driver-service/pom.xml
+++ b/cab-app-driver-service/pom.xml
@@ -25,6 +25,7 @@
         <cab-app-exception-handling-starter.version>0.0.1-SNAPSHOT</cab-app-exception-handling-starter.version>
         <cab-app-common.version>0.0.1-SNAPSHOT</cab-app-common.version>
         <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     </properties>
     
     <dependencyManagement>
@@ -170,4 +171,84 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>coverageVerify</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/persistence/model/**/*</exclude>
+                                <exclude>**/persistence/repository/**/*</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                        <format>HTML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>coverageTest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/persistence/model/**/*</exclude>
+                                <exclude>**/persistence/repository/**/*</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                        <format>HTML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/client/DirectRideClient.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/client/DirectRideClient.java
@@ -3,6 +3,7 @@ package by.arvisit.cabapp.driverservice.client;
 import java.util.Map;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
 
+@Profile({ "dev", "itest" })
 @FeignClient(name = "cab-app-rides-service", url = "${spring.settings.cab-app-rides-service.uri}",
         configuration = CabAppFeignClientConfiguration.class)
 public interface DirectRideClient extends RideClient {

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/controller/DriverController.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/controller/DriverController.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DriverController {
 
     private static final String IS_AVAILABLE_KEY = "isAvailable";
-    private static final String PATCH_VALIDATION_NOT_NULL_MESSAGE_KEY = "{by.arvisit.cabapp.driverservice.controller.DriverController.patch.NotNull.message}";
+    private static final String REQUEST_PARAMS_VALIDATION_NOT_ALLOWED_KEYS_MESSAGE = "{by.arvisit.cabapp.driverservice.controller.DriverController.requestParams.MapContainsAllowedKeys.message}";
     private static final String PATCH_VALIDATION_SIZE_MESSAGE_KEY = "{by.arvisit.cabapp.driverservice.controller.DriverController.patch.Size.message}";
     private static final String PATCH_VALIDATION_AVAILABILITY_NOT_NULL_MESSAGE_KEY = "{by.arvisit.cabapp.driverservice.controller.DriverController.patch.isAvailable.NotNull.message}";
     private final DriverService driverService;
@@ -115,7 +115,6 @@ public class DriverController {
     @PatchMapping("/{id}/availability")
     public DriverResponseDto updateAvailability(@PathVariable @UUID String id,
             @RequestBody
-            @NotNull(message = PATCH_VALIDATION_NOT_NULL_MESSAGE_KEY)
             @Valid
             @MapContainsKey(IS_AVAILABLE_KEY)
             @Size(min = 1, max = 1, message = PATCH_VALIDATION_SIZE_MESSAGE_KEY) Map<String, @NotNull(

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/controller/DriverController.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/controller/DriverController.java
@@ -44,7 +44,6 @@ import lombok.extern.slf4j.Slf4j;
 public class DriverController {
 
     private static final String IS_AVAILABLE_KEY = "isAvailable";
-    private static final String REQUEST_PARAMS_VALIDATION_NOT_ALLOWED_KEYS_MESSAGE = "{by.arvisit.cabapp.driverservice.controller.DriverController.requestParams.MapContainsAllowedKeys.message}";
     private static final String PATCH_VALIDATION_SIZE_MESSAGE_KEY = "{by.arvisit.cabapp.driverservice.controller.DriverController.patch.Size.message}";
     private static final String PATCH_VALIDATION_AVAILABILITY_NOT_NULL_MESSAGE_KEY = "{by.arvisit.cabapp.driverservice.controller.DriverController.patch.isAvailable.NotNull.message}";
     private final DriverService driverService;

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/dto/CarRequestDto.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/dto/CarRequestDto.java
@@ -16,6 +16,7 @@ public record CarRequestDto(
         @NotNull(message = "{by.arvisit.cabapp.driverservice.dto.CarRequestDto.colorId.NotNull.message}")
         @IsColorExistById
         Integer colorId,
+        @NotNull(message = "{by.arvisit.cabapp.driverservice.dto.CarRequestDto.registrationNumber.NotNull.message}")
         @Pattern(regexp = CAR_REGISTRATION_NUMBER_BY,
             message = "{by.arvisit.cabapp.driverservice.dto.CarRequestDto.registrationNumber.Pattern.message}")
         String registrationNumber) {

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/dto/DriverRequestDto.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/dto/DriverRequestDto.java
@@ -16,8 +16,10 @@ public record DriverRequestDto(
         @Size(max = 100, message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.name.Size.message}")
         String name,
         @NotBlank(message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.NotBlank.message}")
+        @Size(max = 100, message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.Size.message}")
         @Email(message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.Email.message}")
         String email,
+        @NotNull(message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.cardNumber.NotNull.message}")
         @Pattern(regexp = CARD_NUMBER,
             message = "{by.arvisit.cabapp.driverservice.dto.DriverRequestDto.cardNumber.Pattern.message}")
         String cardNumber,

--- a/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/mapper/DriverMapper.java
+++ b/cab-app-driver-service/src/main/java/by/arvisit/cabapp/driverservice/mapper/DriverMapper.java
@@ -8,15 +8,18 @@ import org.mapstruct.MappingTarget;
 import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
 import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
 import by.arvisit.cabapp.driverservice.persistence.model.Driver;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING,
         builder = @Builder(disableBuilder = true),
         uses = { CarMapper.class })
-public abstract class DriverMapper {
+public interface DriverMapper {
 
-    public abstract DriverResponseDto fromEntityToResponseDto(Driver entity);
+    DriverResponseDto fromEntityToResponseDto(Driver entity);
 
-    public abstract Driver fromRequestDtoToEntity(DriverRequestDto dto);
+    @Mapping(target = "isAvailable", ignore = true)
+    Driver fromRequestDtoToEntity(DriverRequestDto dto);
 
-    public abstract void updateEntityWithRequestDto(DriverRequestDto dto, @MappingTarget Driver entity);
+    @Mapping(target = "isAvailable", ignore = true)
+    void updateEntityWithRequestDto(DriverRequestDto dto, @MappingTarget Driver entity);
 }

--- a/cab-app-driver-service/src/main/resources/messages.properties
+++ b/cab-app-driver-service/src/main/resources/messages.properties
@@ -1,12 +1,15 @@
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.name.NotBlank.message=Name should not be blank
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.name.Size.message=Name should be no longer than {max}
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.NotBlank.message=Email should not be blank
+by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.Size.message=Email should be no longer than {max}
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.email.Email.message=Email should be well-formed
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.cardNumber.Pattern.message=Card number should consist of 16 digits
+by.arvisit.cabapp.driverservice.dto.DriverRequestDto.cardNumber.NotNull.message=Card number should not be null
 by.arvisit.cabapp.driverservice.dto.DriverRequestDto.car.NotNull.message=Car data should not be null
 
 by.arvisit.cabapp.driverservice.dto.CarRequestDto.manufacturerId.NotNull.message=Car manufacturer id should not be null
 by.arvisit.cabapp.driverservice.dto.CarRequestDto.colorId.NotNull.message=Car color id should not be null
+by.arvisit.cabapp.driverservice.dto.CarRequestDto.registrationNumber.NotNull.message=Car registration number should not be null
 by.arvisit.cabapp.driverservice.dto.CarRequestDto.registrationNumber.Pattern.message=Cars with ICE should have registration number according to pattern - 0000AA-1 (4 digits, 2 chars from (A, B, E, I, K, M, H, O, P, C, T, X), dash, 1 digit from 1 to 7). For electric cars - E000AA-1 (char E, 3 digits, 2 chars from (A, B, E, I, K, M, H, O, P, C, T, X), dash, 1 digit from 1 to 7)
 
 by.arvisit.cabapp.driverservice.persistence.model.Color.id.EntityNotFoundException.template=Found no color with id {0}
@@ -22,7 +25,6 @@ by.arvisit.cabapp.driverservice.persistence.model.Driver.email.UsernameAlreadyEx
 by.arvisit.cabapp.driverservice.validation.IsColorExistById.message=There is no color with id: ${validatedValue}
 by.arvisit.cabapp.driverservice.validation.IsCarManufacturerExistById.message=There is no car manufacturer with id: ${validatedValue}
 
-by.arvisit.cabapp.driverservice.controller.DriverController.patch.NotNull.message=Driver patch should not be null
 by.arvisit.cabapp.driverservice.controller.DriverController.patch.Size.message=Patch should contain one key:value pair
 by.arvisit.cabapp.driverservice.controller.DriverController.patch.isAvailable.NotNull.message=isAvailable value should not be null
 

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarControllerTest.java
@@ -19,8 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -138,7 +136,7 @@ class CarControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.CarControllerTest#malformedUUIDs")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedUUIDs")
         void shouldReturn400_whenMalformedId(String id) throws Exception {
             String expectedContent = MALFORMED_UUID_MESSAGE;
 
@@ -206,13 +204,5 @@ class CarControllerTest {
             assertThat(result)
                     .isEqualTo(responseDto);
         }
-
     }
-
-    static Stream<String> malformedUUIDs() {
-        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
-                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
-                "111122223333-444");
-    }
-
 }

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarControllerTest.java
@@ -1,0 +1,218 @@
+package by.arvisit.cabapp.driverservice.controller;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_CAR_ID_STRING;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_CARS;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_CARS_ID_TEMPLATE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.CarResponseDto;
+import by.arvisit.cabapp.driverservice.service.CarService;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+import jakarta.persistence.EntityNotFoundException;
+
+@WebMvcTest(controllers = CarController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class CarControllerTest {
+
+    private static final String MALFORMED_UUID_MESSAGE = "must be a valid UUID";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CarService carService;
+
+    @Nested
+    class GetCars {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarResponseDto> responseDto = getCarResponseDtoInListContainer()
+                    .build();
+
+            when(carService.getCars(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_CARS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldReturnValidCars_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarResponseDto> responseDto = getCarResponseDtoInListContainer()
+                    .build();
+
+            when(carService.getCars(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CARS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarResponseDto> responseDto = getCarResponseDtoInListContainer()
+                    .build();
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            when(carService.getCars(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CARS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(carService, times(1)).getCars(pageable);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<CarResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<CarResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+    }
+
+    @Nested
+    class GetCarById {
+
+        @Test
+        void shouldReturn200_whenValidInput() throws Exception {
+            mockMvc.perform(get(URL_CARS_ID_TEMPLATE, DEFAULT_CAR_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.CarControllerTest#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_CARS_ID_TEMPLATE, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            when(carService.getCarById(anyString()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(get(URL_CARS_ID_TEMPLATE, DEFAULT_CAR_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void shouldReturnValidCar_whenExistingId() throws Exception {
+            String existingId = DEFAULT_CAR_ID_STRING;
+            CarResponseDto responseDto = getCarResponseDto().build();
+
+            when(carService.getCarById(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CARS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            String existingId = DEFAULT_CAR_ID_STRING;
+            CarResponseDto responseDto = getCarResponseDto().build();
+
+            when(carService.getCarById(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CARS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(carService, times(1)).getCarById(existingId);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            CarResponseDto result = objectMapper.readValue(actualResponseBody, CarResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+    }
+
+    static Stream<String> malformedUUIDs() {
+        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
+                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444");
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarManufacturerControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/CarManufacturerControllerTest.java
@@ -1,0 +1,115 @@
+package by.arvisit.cabapp.driverservice.controller;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_CAR_MANUFACTURERS;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturerResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.CarManufacturerResponseDto;
+import by.arvisit.cabapp.driverservice.service.CarManufacturerService;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+
+@WebMvcTest(controllers = CarManufacturerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class CarManufacturerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CarManufacturerService carManufacturerService;
+
+    @Nested
+    class GetCarManufacturers {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarManufacturerResponseDto> responseDto = getCarManufacturerResponseDtoInListContainer()
+                    .build();
+
+            when(carManufacturerService.getCarManufacturers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_CAR_MANUFACTURERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldReturnValidCarManufacturers_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarManufacturerResponseDto> responseDto = getCarManufacturerResponseDtoInListContainer()
+                    .build();
+
+            when(carManufacturerService.getCarManufacturers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CAR_MANUFACTURERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<CarManufacturerResponseDto> responseDto = getCarManufacturerResponseDtoInListContainer()
+                    .build();
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            when(carManufacturerService.getCarManufacturers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_CAR_MANUFACTURERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(carManufacturerService, times(1)).getCarManufacturers(pageable);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<CarManufacturerResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<CarManufacturerResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/ColorControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/ColorControllerTest.java
@@ -1,0 +1,115 @@
+package by.arvisit.cabapp.driverservice.controller;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_COLORS;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColorResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.ColorResponseDto;
+import by.arvisit.cabapp.driverservice.service.ColorService;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+
+@WebMvcTest(controllers = ColorController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class ColorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private ColorService colorService;
+
+    @Nested
+    class GetColors {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<ColorResponseDto> responseDto = getColorResponseDtoInListContainer()
+                    .build();
+
+            when(colorService.getColors(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_COLORS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldReturnValidColors_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<ColorResponseDto> responseDto = getColorResponseDtoInListContainer()
+                    .build();
+
+            when(colorService.getColors(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_COLORS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<ColorResponseDto> responseDto = getColorResponseDtoInListContainer()
+                    .build();
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            when(colorService.getColors(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_COLORS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(colorService, times(1)).getColors(pageable);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<ColorResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<ColorResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
@@ -1,0 +1,1567 @@
+package by.arvisit.cabapp.driverservice.controller;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.COLOR_ID_WHITE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_CAR_MANUFACTURER_ID;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_DRIVER_EMAIL;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_DRIVER_ID_STRING;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.IS_AVAILABLE_KEY;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.IS_AVAILABLE_REQUEST_PARAM;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.NAME_REQUEST_PARAM;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.NOT_ALLOWED_REQUEST_PARAM;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_AVAILABLE_DRIVERS;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_DRIVERS;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_DRIVERS_EMAIL_TEMPLATE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_DRIVERS_ID_AVAILABILITY_TEMPLATE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_DRIVERS_ID_TEMPLATE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.URL_DRIVERS_PARAM_VALUE_TEMPLATE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverRequestDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.CarRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
+import by.arvisit.cabapp.driverservice.service.CarManufacturerService;
+import by.arvisit.cabapp.driverservice.service.ColorService;
+import by.arvisit.cabapp.driverservice.service.DriverService;
+import by.arvisit.cabapp.driverservice.util.DriverTestData;
+import by.arvisit.cabapp.exceptionhandlingstarter.exception.UsernameAlreadyExistsException;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+import jakarta.persistence.EntityNotFoundException;
+
+@WebMvcTest(controllers = DriverController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class DriverControllerTest {
+
+    private static final String SIZE_NAME_MESSAGE = "Name should be no longer than 100";
+    private static final String SIZE_EMAIL_MESSAGE = "Email should be no longer than 100";
+    private static final String NOT_BLANK_NAME_MESSAGE = "Name should not be blank";
+    private static final String NOT_BLANK_EMAIL_MESSAGE = "Email should not be blank";
+    private static final String NOT_NULL_CARD_NUMBER_MESSAGE = "Card number should not be null";
+    private static final String NOT_NULL_CAR_MESSAGE = "Car data should not be null";
+    private static final String NOT_NULL_CAR_COLOR_MESSAGE = "Car color id should not be null";
+    private static final String NO_SUCH_CAR_COLOR_MESSAGE = "There is no color with id: " + COLOR_ID_WHITE;
+    private static final String NOT_NULL_CAR_MANUFACTURER_MESSAGE = "Car manufacturer id should not be null";
+    private static final String NO_SUCH_CAR_MANUFACTURER_MESSAGE = "There is no car manufacturer with id: "
+            + DEFAULT_CAR_MANUFACTURER_ID;
+    private static final String NOT_NULL_CAR_REGISTRATION_NUMBER_MESSAGE = "Car registration number should not be null";
+    private static final String PATTERN_CAR_REGISTRATION_NUMBER_MESSAGE = "Cars with ICE should have registration number according to pattern - 0000AA-1 (4 digits, 2 chars from (A, B, E, I, K, M, H, O, P, C, T, X), dash, 1 digit from 1 to 7). For electric cars - E000AA-1 (char E, 3 digits, 2 chars from (A, B, E, I, K, M, H, O, P, C, T, X), dash, 1 digit from 1 to 7)";
+    private static final String MALFORMED_EMAIL_MESSAGE = "Email should be well-formed";
+    private static final String MALFORMED_UUID_MESSAGE = "must be a valid UUID";
+    private static final String PATTERN_CARD_NUMBER_MESSAGE = "Card number should consist of 16 digits";
+    private static final String UNPARSEABLE_BOOLEAN_MESSAGE = "Unparseable boolean values detected";
+    private static final String PATCH_WITH_NO_IS_AVAILABLE_KEY_MESSAGE = "Patch should contain key: isAvailable";
+    private static final String UNREADABLE_REQUEST_BODY_MESSAGE = "Request body is missing or could not be read";
+    private static final String MORE_THAN_ONE_KEY_VALUE_PAIR_MESSAGE = "Patch should contain one key:value pair";
+    private static final String PATCH_NULL_VALUE_FOR_IS_AVAILABLE_KEY_MESSAGE = "isAvailable value should not be null";
+    private static final String LETTERS_101 = "TVQDfZXYIzFNzhzskpZiwULzGOikAuVtwRPnYaCjQjdeMJKcEbvpuiQNUmaERmPtyDwFHPHaiHnWZHmoXrRNUVDWVOkZFhlVOBuMC";
+    private static final String EMPTY_STRING = "";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private DriverService driverService;
+    @MockBean
+    private CarManufacturerService carManufacturerService;
+    @MockBean
+    private ColorService colorService;
+
+    @Nested
+    class SaveDriver {
+
+        @Test
+        void shouldReturn201_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.save(any(DriverRequestDto.class)))
+                    .thenReturn(responseDto);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            verify(driverService, times(1)).save(requestDto);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverResponseDto result = objectMapper.readValue(actualResponseBody, DriverResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidDriver_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.save(any(DriverRequestDto.class)))
+                    .thenReturn(responseDto);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        void shouldReturn400_whenBlankName(String name) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withName(name)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_BLANK_NAME_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNameLongerThan100() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withName(LETTERS_101)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = SIZE_NAME_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        void shouldReturn400_whenBlankEmail(String email) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(email)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_BLANK_EMAIL_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        void shouldReturn400_whenMalformedEmail(String email) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(email)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = MALFORMED_EMAIL_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenEmailLongerThan100() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(LETTERS_101)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = SIZE_EMAIL_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCardNumbers")
+        void shouldReturn400_whenMalformedCardNumber(String cardNumber) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCardNumber(cardNumber)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = PATTERN_CARD_NUMBER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCardNumber() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCardNumber(null)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CARD_NUMBER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCar() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(null)
+                    .build();
+
+            String expectedContent = NOT_NULL_CAR_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarColor() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withColorId(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_COLOR_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNoSuchCarColor() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withColorId(COLOR_ID_WHITE)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(false);
+
+            String expectedContent = NO_SUCH_CAR_COLOR_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarManufacturer() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withManufacturerId(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_MANUFACTURER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNoSuchCarManufacturer() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withManufacturerId(DEFAULT_CAR_MANUFACTURER_ID)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(false);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NO_SUCH_CAR_MANUFACTURER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarRegistrationNumber() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withRegistrationNumber(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_REGISTRATION_NUMBER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCarRegistrationNumbers")
+        void shouldReturn400_whenMalformedCarRegistrationNumber(String registrationNumber) throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withRegistrationNumber(registrationNumber)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = PATTERN_CAR_REGISTRATION_NUMBER_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenEmailInUse() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(driverService.save(any(DriverRequestDto.class)))
+                    .thenThrow(UsernameAlreadyExistsException.class);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            mockMvc.perform(post(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    class UpdateDriver {
+
+        @Test
+        void shouldReturn200_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(driverService.update(anyString(), any(DriverRequestDto.class)))
+                    .thenThrow(EntityNotFoundException.class);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.update(anyString(), any(DriverRequestDto.class)))
+                    .thenReturn(responseDto);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).update(existingId, requestDto);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverResponseDto result = objectMapper.readValue(actualResponseBody, DriverResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidDriver_whenValidInput() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.update(anyString(), any(DriverRequestDto.class)))
+                    .thenReturn(responseDto);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        void shouldReturn400_whenBlankName(String name) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withName(name)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_BLANK_NAME_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNameLongerThan100() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withName(LETTERS_101)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = SIZE_NAME_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        void shouldReturn400_whenBlankEmail(String email) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(email)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_BLANK_EMAIL_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        void shouldReturn400_whenMalformedEmail(String email) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(email)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = MALFORMED_EMAIL_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenEmailLongerThan100() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withEmail(LETTERS_101)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = SIZE_EMAIL_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCardNumbers")
+        void shouldReturn400_whenMalformedCardNumber(String cardNumber) throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCardNumber(cardNumber)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = PATTERN_CARD_NUMBER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCardNumber() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCardNumber(null)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CARD_NUMBER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCar() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(null)
+                    .build();
+
+            String expectedContent = NOT_NULL_CAR_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarColor() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withColorId(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_COLOR_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNoSuchCarColor() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withColorId(COLOR_ID_WHITE)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(false);
+
+            String expectedContent = NO_SUCH_CAR_COLOR_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarManufacturer() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withManufacturerId(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_MANUFACTURER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNoSuchCarManufacturer() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withManufacturerId(DEFAULT_CAR_MANUFACTURER_ID)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(false);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NO_SUCH_CAR_MANUFACTURER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullCarRegistrationNumber() throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withRegistrationNumber(null)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = NOT_NULL_CAR_REGISTRATION_NUMBER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCarRegistrationNumbers")
+        void shouldReturn400_whenMalformedCarRegistrationNumber(String registrationNumber) throws Exception {
+            CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
+                    .withRegistrationNumber(registrationNumber)
+                    .build();
+            DriverRequestDto requestDto = getDriverRequestDto()
+                    .withCar(carRequestDto)
+                    .build();
+
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            String expectedContent = PATTERN_CAR_REGISTRATION_NUMBER_MESSAGE;
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenEmailInUse() throws Exception {
+            DriverRequestDto requestDto = getDriverRequestDto().build();
+
+            when(driverService.update(anyString(), any(DriverRequestDto.class)))
+                    .thenThrow(UsernameAlreadyExistsException.class);
+            when(carManufacturerService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+            when(colorService.existsById(Mockito.anyInt()))
+                    .thenReturn(true);
+
+            mockMvc.perform(put(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    class DeleteDriver {
+
+        @Test
+        void shouldReturn204_whenValidInput() throws Exception {
+            mockMvc.perform(delete(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            doThrow(EntityNotFoundException.class).when(driverService)
+                    .delete(anyString());
+
+            mockMvc.perform(delete(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(delete(URL_DRIVERS_ID_TEMPLATE, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            doNothing().when(driverService)
+                    .delete(anyString());
+
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            mockMvc.perform(delete(URL_DRIVERS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+
+            verify(driverService, times(1)).delete(existingId);
+        }
+    }
+
+    @Nested
+    class GetDriverById {
+
+        @Test
+        void shouldReturn200_whenValidInput() throws Exception {
+            mockMvc.perform(get(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVERS_ID_TEMPLATE, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            when(driverService.getDriverById(anyString()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(get(URL_DRIVERS_ID_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void shouldReturnValidDriver_whenExistingId() throws Exception {
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.getDriverById(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.getDriverById(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS_ID_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).getDriverById(existingId);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverResponseDto result = objectMapper.readValue(actualResponseBody, DriverResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+    }
+
+    @Nested
+    class GetDriverByEmail {
+
+        @Test
+        void shouldReturn200_whenValidInput() throws Exception {
+            mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, DEFAULT_DRIVER_EMAIL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        void shouldReturn400_whenMalformedEmail(String email) throws Exception {
+            mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, email)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingEmail() throws Exception {
+            when(driverService.getDriverByEmail(anyString()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, DEFAULT_DRIVER_EMAIL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void shouldReturnValidDriver_whenExistingEmail() throws Exception {
+            String existingEmail = DEFAULT_DRIVER_EMAIL;
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.getDriverByEmail(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, existingEmail)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingEmail() throws Exception {
+            String existingEmail = DEFAULT_DRIVER_EMAIL;
+            DriverResponseDto responseDto = getDriverResponseDto().build();
+
+            when(driverService.getDriverByEmail(anyString()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, existingEmail)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).getDriverByEmail(existingEmail);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverResponseDto result = objectMapper.readValue(actualResponseBody, DriverResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+    }
+
+    @Nested
+    class GetDrivers {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+
+            when(driverService.getDrivers(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldReturnValidDrivers_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+
+            when(driverService.getDrivers(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            when(driverService.getDrivers(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).getDrivers(pageable, Collections.emptyMap());
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<DriverResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<DriverResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturn400_whenNotAllowedRequestParam() throws Exception {
+            mockMvc.perform(get(URL_DRIVERS_PARAM_VALUE_TEMPLATE, NOT_ALLOWED_REQUEST_PARAM, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void shouldReturn400_whenBlankRequestParamValue() throws Exception {
+            mockMvc.perform(get(URL_DRIVERS_PARAM_VALUE_TEMPLATE, NAME_REQUEST_PARAM, EMPTY_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedBooleans")
+        void shouldReturn400_whenNotParseableBooleanForIsAvailableRequestParam(String value) throws Exception {
+            String expectedContent = UNPARSEABLE_BOOLEAN_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVERS_PARAM_VALUE_TEMPLATE, IS_AVAILABLE_REQUEST_PARAM, value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+    }
+
+    @Nested
+    class GetAvailableDrivers {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+
+            when(driverService.getAvailableDrivers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_AVAILABLE_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldReturnValidDrivers_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+
+            when(driverService.getAvailableDrivers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_AVAILABLE_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverResponseDto> responseDto = getDriverResponseDtoInListContainer()
+                    .build();
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            when(driverService.getAvailableDrivers(any(Pageable.class)))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_AVAILABLE_DRIVERS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).getAvailableDrivers(pageable);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<DriverResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<DriverResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+    }
+
+    @Nested
+    class UpdateAvailability {
+
+        @Test
+        void shouldReturn200_whenValidInput() throws Exception {
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, true);
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, true);
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, true);
+
+            when(driverService.updateAvailability(anyString(), anyBoolean()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenValidInput() throws Exception {
+            boolean newIsAvailable = true;
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, newIsAvailable);
+            DriverResponseDto responseDto = getDriverResponseDto()
+                    .withIsAvailable(newIsAvailable)
+                    .build();
+
+            when(driverService.updateAvailability(anyString(), anyBoolean()))
+                    .thenReturn(responseDto);
+
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverService, times(1)).updateAvailability(existingId, newIsAvailable);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverResponseDto result = objectMapper.readValue(actualResponseBody, DriverResponseDto.class);
+
+            assertThat(result)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidDriver_whenValidInput() throws Exception {
+            boolean newIsAvailable = true;
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, newIsAvailable);
+            DriverResponseDto responseDto = getDriverResponseDto()
+                    .withIsAvailable(newIsAvailable)
+                    .build();
+
+            when(driverService.updateAvailability(anyString(), anyBoolean()))
+                    .thenReturn(responseDto);
+
+            String existingId = DEFAULT_DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, existingId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldReturn400_whenNullBody() throws Exception {
+            Map<String, Boolean> requestDto = null;
+
+            String expectedContent = UNREADABLE_REQUEST_BODY_MESSAGE;
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenMoreThanOneKeyValuePairMapInBody() throws Exception {
+            boolean newIsAvailable = true;
+            Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, newIsAvailable, NAME_REQUEST_PARAM,
+                    newIsAvailable);
+
+            String expectedContent = MORE_THAN_ONE_KEY_VALUE_PAIR_MESSAGE;
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenBodyContainsNoIsAvailableKey() throws Exception {
+            Map<String, Boolean> requestDto = Map.of(NAME_REQUEST_PARAM, true);
+
+            String expectedContent = PATCH_WITH_NO_IS_AVAILABLE_KEY_MESSAGE;
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenBooleanValueInBodyIsNull() throws Exception {
+            Map<String, Boolean> requestDto = Collections.singletonMap(IS_AVAILABLE_KEY, null);
+
+            String expectedContent = PATCH_NULL_VALUE_FOR_IS_AVAILABLE_KEY_MESSAGE;
+
+            mockMvc.perform(patch(URL_DRIVERS_ID_AVAILABILITY_TEMPLATE, DEFAULT_DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+    }
+
+    static Stream<String> blankStrings() {
+        return Stream.of("", "   ", null);
+    }
+
+    static Stream<String> malformedEmails() {
+        return Stream.of("   ", "not-email", "not-email.mail.com", "not email", "not email@mail.com");
+    }
+
+    static Stream<String> malformedCardNumbers() {
+        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444");
+    }
+
+    static Stream<String> malformedCarRegistrationNumbers() {
+        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444", "A000AA-1", "0000YA-1",
+                "0000AA1", "0000AA_1", "0000AA-0", "0000AA-9", "E000YA-1", "E000AA1", "E000AA_1", "E000AA-0",
+                "E000AA-9");
+    }
+
+    static Stream<String> malformedUUIDs() {
+        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
+                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444");
+    }
+
+    static Stream<String> malformedBooleans() {
+        return Stream.of("", "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444", "truth", "lies", "trui", "falce");
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
@@ -510,7 +510,7 @@ class DriverControllerTest {
         }
 
         @Test
-        void shouldReturn400_whenEmailInUse() throws Exception {
+        void shouldReturn409_whenEmailInUse() throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto().build();
 
             when(driverService.save(any(DriverRequestDto.class)))
@@ -969,7 +969,7 @@ class DriverControllerTest {
         }
 
         @Test
-        void shouldReturn400_whenEmailInUse() throws Exception {
+        void shouldReturn409_whenEmailInUse() throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto().build();
 
             when(driverService.update(anyString(), any(DriverRequestDto.class)))

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/controller/DriverControllerTest.java
@@ -40,7 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -188,7 +187,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#blankStrings")
         void shouldReturn400_whenBlankName(String name) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withName(name)
@@ -233,7 +232,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#blankStrings")
         void shouldReturn400_whenBlankEmail(String email) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withEmail(email)
@@ -256,7 +255,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedEmails")
         void shouldReturn400_whenMalformedEmail(String email) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withEmail(email)
@@ -301,7 +300,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCardNumbers")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedCardNumbers")
         void shouldReturn400_whenMalformedCardNumber(String cardNumber) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withCardNumber(cardNumber)
@@ -484,7 +483,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCarRegistrationNumbers")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedCarRegistrationNumbers")
         void shouldReturn400_whenMalformedCarRegistrationNumber(String registrationNumber) throws Exception {
             CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
                     .withRegistrationNumber(registrationNumber)
@@ -550,7 +549,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedUUIDs")
         void shouldReturn400_whenMalformedId(String id) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto().build();
 
@@ -647,7 +646,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#blankStrings")
         void shouldReturn400_whenBlankName(String name) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withName(name)
@@ -692,7 +691,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#blankStrings")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#blankStrings")
         void shouldReturn400_whenBlankEmail(String email) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withEmail(email)
@@ -715,7 +714,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedEmails")
         void shouldReturn400_whenMalformedEmail(String email) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withEmail(email)
@@ -760,7 +759,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCardNumbers")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedCardNumbers")
         void shouldReturn400_whenMalformedCardNumber(String cardNumber) throws Exception {
             DriverRequestDto requestDto = getDriverRequestDto()
                     .withCardNumber(cardNumber)
@@ -943,7 +942,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedCarRegistrationNumbers")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedCarRegistrationNumbers")
         void shouldReturn400_whenMalformedCarRegistrationNumber(String registrationNumber) throws Exception {
             CarRequestDto carRequestDto = DriverTestData.getCarRequestDto()
                     .withRegistrationNumber(registrationNumber)
@@ -1013,7 +1012,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedUUIDs")
         void shouldReturn400_whenMalformedId(String id) throws Exception {
             String expectedContent = MALFORMED_UUID_MESSAGE;
 
@@ -1054,7 +1053,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedUUIDs")
         void shouldReturn400_whenMalformedId(String id) throws Exception {
             String expectedContent = MALFORMED_UUID_MESSAGE;
 
@@ -1138,7 +1137,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedEmails")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedEmails")
         void shouldReturn400_whenMalformedEmail(String email) throws Exception {
             mockMvc.perform(get(URL_DRIVERS_EMAIL_TEMPLATE, email)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -1291,7 +1290,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedBooleans")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedBooleans")
         void shouldReturn400_whenNotParseableBooleanForIsAvailableRequestParam(String value) throws Exception {
             String expectedContent = UNPARSEABLE_BOOLEAN_MESSAGE;
 
@@ -1387,7 +1386,7 @@ class DriverControllerTest {
         }
 
         @ParameterizedTest
-        @MethodSource("by.arvisit.cabapp.driverservice.controller.DriverControllerTest#malformedUUIDs")
+        @MethodSource("by.arvisit.cabapp.driverservice.util.DriverTestData#malformedUUIDs")
         void shouldReturn400_whenMalformedId(String id) throws Exception {
             Map<String, Boolean> requestDto = Map.of(IS_AVAILABLE_KEY, true);
 
@@ -1533,35 +1532,5 @@ class DriverControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(content().string(containsString(expectedContent)));
         }
-
-    }
-
-    static Stream<String> blankStrings() {
-        return Stream.of("", "   ", null);
-    }
-
-    static Stream<String> malformedEmails() {
-        return Stream.of("   ", "not-email", "not-email.mail.com", "not email", "not email@mail.com");
-    }
-
-    static Stream<String> malformedCardNumbers() {
-        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444");
-    }
-
-    static Stream<String> malformedCarRegistrationNumbers() {
-        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444", "A000AA-1", "0000YA-1",
-                "0000AA1", "0000AA_1", "0000AA-0", "0000AA-9", "E000YA-1", "E000AA1", "E000AA_1", "E000AA-0",
-                "E000AA-9");
-    }
-
-    static Stream<String> malformedUUIDs() {
-        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
-                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
-                "111122223333-444");
-    }
-
-    static Stream<String> malformedBooleans() {
-        return Stream.of("", "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
-                "111122223333-444", "truth", "lies", "trui", "falce");
     }
 }

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/CarManufacturerMapperTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/CarManufacturerMapperTest.java
@@ -1,0 +1,28 @@
+package by.arvisit.cabapp.driverservice.mapper;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturer;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturerResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import by.arvisit.cabapp.driverservice.dto.CarManufacturerResponseDto;
+import by.arvisit.cabapp.driverservice.persistence.model.CarManufacturer;
+
+class CarManufacturerMapperTest {
+
+    private CarManufacturerMapper carManufacturerMapper = Mappers.getMapper(CarManufacturerMapper.class);
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        CarManufacturer entity = getCarManufacturer().build();
+        CarManufacturerResponseDto expectedResponseDto = getCarManufacturerResponseDto().build();
+
+        CarManufacturerResponseDto actualResponseDto = carManufacturerMapper.fromEntityToResponseDto(entity);
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/CarMapperTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/CarMapperTest.java
@@ -1,0 +1,100 @@
+package by.arvisit.cabapp.driverservice.mapper;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.COLOR_ID_BLACK;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.COLOR_NAME_BLACK;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCar;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturer;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarRequestDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import by.arvisit.cabapp.driverservice.dto.CarRequestDto;
+import by.arvisit.cabapp.driverservice.dto.CarResponseDto;
+import by.arvisit.cabapp.driverservice.persistence.model.Car;
+import by.arvisit.cabapp.driverservice.persistence.model.CarManufacturer;
+import by.arvisit.cabapp.driverservice.persistence.model.Color;
+import by.arvisit.cabapp.driverservice.service.CarManufacturerService;
+import by.arvisit.cabapp.driverservice.service.ColorService;
+
+@ExtendWith(MockitoExtension.class)
+class CarMapperTest {
+
+    private static final String ID_FIELD = "id";
+
+    @InjectMocks
+    private CarMapper carMapper = Mappers.getMapper(CarMapper.class);
+    @Mock
+    private ColorService colorService;
+    @Mock
+    private CarManufacturerService carManufacturerService;
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        Car entity = getCar().build();
+
+        CarResponseDto actualResponseDto = carMapper.fromEntityToResponseDto(entity);
+        CarResponseDto expectedResponseDto = getCarResponseDto().build();
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+
+    @Test
+    void shouldMapFromRequestDtoToEntity() {
+        Color color = getColor().build();
+        CarManufacturer carManufacturer = getCarManufacturer().build();
+
+        when(colorService.getColorEntityById(any(Integer.class)))
+                .thenReturn(color);
+        when(carManufacturerService.getCarManufacturerEntityById(any(Integer.class)))
+                .thenReturn(carManufacturer);
+
+        CarRequestDto requestDto = getCarRequestDto().build();
+        Car actualEntity = carMapper.fromRequestDtoToEntity(requestDto);
+        Car expectedEntity = getCar().build();
+
+        assertThat(actualEntity)
+                .usingRecursiveComparison()
+                .ignoringFields(ID_FIELD)
+                .isEqualTo(expectedEntity);
+
+    }
+
+    @Test
+    void shouldUpdateEntityWithRequestDto() {
+        Color color = getColor()
+                .withId(COLOR_ID_BLACK)
+                .withName(COLOR_NAME_BLACK)
+                .build();
+        CarManufacturer carManufacturer = getCarManufacturer().build();
+
+        when(colorService.getColorEntityById(any(Integer.class)))
+                .thenReturn(color);
+        when(carManufacturerService.getCarManufacturerEntityById(any(Integer.class)))
+                .thenReturn(carManufacturer);
+
+        CarRequestDto requestDto = getCarRequestDto()
+                .withColorId(COLOR_ID_BLACK)
+                .build();
+        Car actualEntity = carMapper.fromRequestDtoToEntity(requestDto);
+        Car expectedEntity = getCar()
+                .withColor(color)
+                .build();
+
+        assertThat(actualEntity)
+                .usingRecursiveComparison()
+                .ignoringFields(ID_FIELD)
+                .isEqualTo(expectedEntity);
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/ColorMapperTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/ColorMapperTest.java
@@ -1,0 +1,28 @@
+package by.arvisit.cabapp.driverservice.mapper;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColor;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColorResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import by.arvisit.cabapp.driverservice.dto.ColorResponseDto;
+import by.arvisit.cabapp.driverservice.persistence.model.Color;
+
+class ColorMapperTest {
+
+    private ColorMapper colorMapper = Mappers.getMapper(ColorMapper.class);
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        Color entity = getColor().build();
+        ColorResponseDto expectedResponseDto = getColorResponseDto().build();
+
+        ColorResponseDto actualResponseDto = colorMapper.fromEntityToResponseDto(entity);
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/DriverMapperTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/DriverMapperTest.java
@@ -1,0 +1,80 @@
+package by.arvisit.cabapp.driverservice.mapper;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.NEW_DRIVER_NAME;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCar;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriver;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverRequestDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import by.arvisit.cabapp.driverservice.dto.CarRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
+import by.arvisit.cabapp.driverservice.persistence.model.Car;
+import by.arvisit.cabapp.driverservice.persistence.model.Driver;
+
+@ExtendWith(MockitoExtension.class)
+class DriverMapperTest {
+
+    private static final String IS_AVAILABLE_FIELD = "isAvailable";
+    private static final String ID_FIELD = "id";
+
+    @InjectMocks
+    private DriverMapper driverMapper = Mappers.getMapper(DriverMapper.class);
+    @Mock
+    private CarMapper carMapper;
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        Driver entity = getDriver().build();
+
+        when(carMapper.fromEntityToResponseDto(any(Car.class)))
+                .thenReturn(getCarResponseDto().build());
+
+        DriverResponseDto actualResponseDto = driverMapper.fromEntityToResponseDto(entity);
+        DriverResponseDto expectedResponseDto = getDriverResponseDto().build();
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+
+    @Test
+    void shouldMapFromRequestDtoToEntity() {
+        DriverRequestDto requestDto = getDriverRequestDto().build();
+
+        when(carMapper.fromRequestDtoToEntity(any(CarRequestDto.class)))
+                .thenReturn(getCar().build());
+
+        Driver actualEntity = driverMapper.fromRequestDtoToEntity(requestDto);
+        Driver expectedEntity = getDriver().build();
+
+        assertThat(actualEntity)
+                .usingRecursiveComparison()
+                .ignoringFields(ID_FIELD, IS_AVAILABLE_FIELD)
+                .isEqualTo(expectedEntity);
+    }
+
+    @Test
+    void shouldUpdateEntityWithRequestDto() {
+        DriverRequestDto requestDto = getDriverRequestDto()
+                .withName(NEW_DRIVER_NAME)
+                .build();
+        Driver entityToUpdate = getDriver().build();
+
+        driverMapper.updateEntityWithRequestDto(requestDto, entityToUpdate);
+
+        assertThat(entityToUpdate.getName())
+                .isEqualTo(requestDto.name());
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/DriversFilterParamsMapperTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/mapper/DriversFilterParamsMapperTest.java
@@ -1,0 +1,42 @@
+package by.arvisit.cabapp.driverservice.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import by.arvisit.cabapp.driverservice.dto.DriversFilterParams;
+import by.arvisit.cabapp.driverservice.util.DriverTestData;
+
+class DriversFilterParamsMapperTest {
+
+    private DriversFilterParamsMapper filterParamsMapper = new DriversFilterParamsMapper();
+
+    @Test
+    void shouldMapFromEmptyMapToFilterParamsDto() {
+        Map<String, String> mapParams = Collections.emptyMap();
+
+        DriversFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        DriversFilterParams expected = DriverTestData.getEmptyDriversFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldMapFromFilledMapToFilterParamsDto() {
+        Map<String, String> mapParams = DriverTestData.getRequestParams();
+
+        DriversFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        DriversFilterParams expected = DriverTestData.getFilledDriversFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/CarManufacturerServiceImplTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/CarManufacturerServiceImplTest.java
@@ -1,0 +1,105 @@
+package by.arvisit.cabapp.driverservice.service.impl;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_CAR_MANUFACTURER_ID;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_CAR_MANUFACTURER_NAME;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturer;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturerResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarManufacturerResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import by.arvisit.cabapp.driverservice.dto.CarManufacturerResponseDto;
+import by.arvisit.cabapp.driverservice.mapper.CarManufacturerMapper;
+import by.arvisit.cabapp.driverservice.persistence.model.CarManufacturer;
+import by.arvisit.cabapp.driverservice.persistence.repository.CarManufacturerRepository;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class CarManufacturerServiceImplTest {
+
+    @InjectMocks
+    private CarManufacturerServiceImpl carManufacturerService;
+    @Mock
+    private CarManufacturerRepository carManufacturerRepository;
+    @Mock
+    private CarManufacturerMapper carManufacturerMapper;
+    @Mock
+    private MessageSource messageSource;
+
+    @Test
+    void shouldReturnEntity_whenGetCarManufacturerEntityByExistingId() {
+        CarManufacturer carManufacturer = getCarManufacturer().build();
+
+        when(carManufacturerRepository.findById(any(Integer.class)))
+                .thenReturn(Optional.of(carManufacturer));
+
+        CarManufacturer actualCarManufacturer = carManufacturerService
+                .getCarManufacturerEntityById(DEFAULT_CAR_MANUFACTURER_ID);
+
+        assertThat(actualCarManufacturer.getId())
+                .isEqualTo(DEFAULT_CAR_MANUFACTURER_ID);
+        assertThat(actualCarManufacturer.getName())
+                .isEqualTo(DEFAULT_CAR_MANUFACTURER_NAME);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetCarManufacturerEntityByNonExistingId() {
+        when(carManufacturerRepository.findById(any(Integer.class)))
+                .thenThrow(EntityNotFoundException.class);
+
+        assertThatThrownBy(() -> carManufacturerService.getCarManufacturerEntityById(DEFAULT_CAR_MANUFACTURER_ID))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnContainerWithCarManufacturerResponseDto_whenGetCarManufacturers() {
+        List<CarManufacturer> carManufacturers = List.of(getCarManufacturer().build());
+        Page<CarManufacturer> carManufacturersPage = new PageImpl<>(carManufacturers);
+        CarManufacturerResponseDto carManufacturerResponseDto = getCarManufacturerResponseDto().build();
+
+        when(carManufacturerRepository.findAll(any(Pageable.class)))
+                .thenReturn(carManufacturersPage);
+        when(carManufacturerMapper.fromEntityToResponseDto(any(CarManufacturer.class)))
+                .thenReturn(carManufacturerResponseDto);
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        assertThat(carManufacturerService.getCarManufacturers(pageable))
+                .isEqualTo(getCarManufacturerResponseDtoInListContainer().build());
+    }
+
+    @Test
+    void shouldReturnTrue_whenCarManufacturerExists() {
+        when(carManufacturerRepository.existsById(any(Integer.class)))
+                .thenReturn(true);
+
+        assertThat(carManufacturerService.existsById(DEFAULT_CAR_MANUFACTURER_ID))
+                .isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenCarManufacturerDoesNotExist() {
+        when(carManufacturerRepository.existsById(any(Integer.class)))
+                .thenReturn(false);
+
+        assertThat(
+                carManufacturerService.existsById(DEFAULT_CAR_MANUFACTURER_ID))
+                .isFalse();
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/CarServiceImplTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/CarServiceImplTest.java
@@ -1,0 +1,85 @@
+package by.arvisit.cabapp.driverservice.service.impl;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_CAR_ID_STRING;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCar;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getCarResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import by.arvisit.cabapp.driverservice.dto.CarResponseDto;
+import by.arvisit.cabapp.driverservice.mapper.CarMapper;
+import by.arvisit.cabapp.driverservice.persistence.model.Car;
+import by.arvisit.cabapp.driverservice.persistence.repository.CarRepository;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class CarServiceImplTest {
+
+    @InjectMocks
+    private CarServiceImpl carService;
+    @Mock
+    private CarRepository carRepository;
+    @Mock
+    private CarMapper carMapper;
+    @Mock
+    private MessageSource messageSource;
+
+    @Test
+    void shouldReturnEntity_whenGetCarEntityByExistingId() {
+        Car car = getCar().build();
+        CarResponseDto carResponseDto = getCarResponseDto().build();
+
+        when(carRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(car));
+        when(carMapper.fromEntityToResponseDto(any(Car.class)))
+                .thenReturn(carResponseDto);
+
+        assertThat(carService.getCarById(DEFAULT_CAR_ID_STRING))
+                .usingRecursiveComparison()
+                .isEqualTo(carResponseDto);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetCarEntityByNonExistingId() {
+        when(carRepository.findById(any(UUID.class)))
+                .thenThrow(EntityNotFoundException.class);
+
+        assertThatThrownBy(() -> carService.getCarById(DEFAULT_CAR_ID_STRING))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnContainerWithCarResponseDto_whenGetCars() {
+        List<Car> cars = List.of(getCar().build());
+        Page<Car> carsPage = new PageImpl<>(cars);
+        CarResponseDto carResponseDto = getCarResponseDto().build();
+
+        when(carRepository.findAll(any(Pageable.class)))
+                .thenReturn(carsPage);
+        when(carMapper.fromEntityToResponseDto(any(Car.class)))
+                .thenReturn(carResponseDto);
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        assertThat(carService.getCars(pageable))
+                .isEqualTo(getCarResponseDtoInListContainer().build());
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/ColorServiceImplTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/ColorServiceImplTest.java
@@ -1,0 +1,103 @@
+package by.arvisit.cabapp.driverservice.service.impl;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.COLOR_ID_WHITE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.COLOR_NAME_WHITE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColor;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColorResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getColorResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import by.arvisit.cabapp.driverservice.dto.ColorResponseDto;
+import by.arvisit.cabapp.driverservice.mapper.ColorMapper;
+import by.arvisit.cabapp.driverservice.persistence.model.Color;
+import by.arvisit.cabapp.driverservice.persistence.repository.ColorRepository;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class ColorServiceImplTest {
+
+    @InjectMocks
+    private ColorServiceImpl colorService;
+    @Mock
+    private ColorRepository colorRepository;
+    @Mock
+    private ColorMapper colorMapper;
+    @Mock
+    private MessageSource messageSource;
+
+    @Test
+    void shouldReturnEntity_whenGetColorEntityByExistingId() {
+        Color color = getColor().build();
+
+        when(colorRepository.findById(any(Integer.class)))
+                .thenReturn(Optional.of(color));
+
+        Color actualColor = colorService.getColorEntityById(COLOR_ID_WHITE);
+
+        assertThat(actualColor.getId())
+                .isEqualTo(COLOR_ID_WHITE);
+        assertThat(actualColor.getName())
+                .isEqualTo(COLOR_NAME_WHITE);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetColorEntityByNonExistingId() {
+        when(colorRepository.findById(any(Integer.class)))
+                .thenThrow(EntityNotFoundException.class);
+
+        assertThatThrownBy(() -> colorService.getColorEntityById(COLOR_ID_WHITE))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnContainerWithColorResponseDto_whenGetColors() {
+        List<Color> colors = List.of(getColor().build());
+        Page<Color> colorsPage = new PageImpl<>(colors);
+        ColorResponseDto colorResponseDto = getColorResponseDto().build();
+
+        when(colorRepository.findAll(any(Pageable.class)))
+                .thenReturn(colorsPage);
+        when(colorMapper.fromEntityToResponseDto(any(Color.class)))
+                .thenReturn(colorResponseDto);
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        assertThat(colorService.getColors(pageable))
+                .isEqualTo(getColorResponseDtoInListContainer().build());
+    }
+
+    @Test
+    void shouldReturnTrue_whenColorExists() {
+        when(colorRepository.existsById(any(Integer.class)))
+                .thenReturn(true);
+
+        assertThat(colorService.existsById(COLOR_ID_WHITE))
+                .isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenColorDoesNotExist() {
+        when(colorRepository.existsById(any(Integer.class)))
+                .thenReturn(false);
+
+        assertThat(colorService.existsById(COLOR_ID_WHITE))
+                .isFalse();
+    }
+
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/DriverServiceImplTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/DriverServiceImplTest.java
@@ -9,6 +9,7 @@ import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriver;
 import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverRequestDto;
 import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDto;
 import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDtoInListContainer;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getEmptyDriversFilterParams;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,6 +40,7 @@ import org.springframework.data.jpa.domain.Specification;
 import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
 import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
 import by.arvisit.cabapp.driverservice.mapper.DriverMapper;
+import by.arvisit.cabapp.driverservice.mapper.DriversFilterParamsMapper;
 import by.arvisit.cabapp.driverservice.persistence.model.Driver;
 import by.arvisit.cabapp.driverservice.persistence.repository.DriverRepository;
 import by.arvisit.cabapp.driverservice.persistence.util.DriverSpecs;
@@ -55,6 +57,8 @@ class DriverServiceImplTest {
     @Mock
     private DriverMapper driverMapper;
     @Mock
+    private DriversFilterParamsMapper filterParamsMapper;
+    @Mock
     private MessageSource messageSource;
     @Mock
     private DriverSpecs driverSpecs;
@@ -69,6 +73,8 @@ class DriverServiceImplTest {
         Page<Driver> driversPage = new PageImpl<>(drivers);
         Specification<Driver> spec = (root, query, cb) -> cb.conjunction();
 
+        when(filterParamsMapper.fromMapParams(any()))
+                .thenReturn(getEmptyDriversFilterParams().build());
         when(driverSpecs.getAllByFilter(any()))
                 .thenReturn(spec);
         when(driverRepository.findAll(spec, pageable))

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/DriverServiceImplTest.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/service/impl/DriverServiceImplTest.java
@@ -1,0 +1,350 @@
+package by.arvisit.cabapp.driverservice.service.impl;
+
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_DRIVER_EMAIL;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_DRIVER_ID_STRING;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.NEW_DRIVER_EMAIL;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.NEW_DRIVER_NAME;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriver;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverRequestDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDto;
+import static by.arvisit.cabapp.driverservice.util.DriverTestData.getDriverResponseDtoInListContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
+import by.arvisit.cabapp.driverservice.mapper.DriverMapper;
+import by.arvisit.cabapp.driverservice.persistence.model.Driver;
+import by.arvisit.cabapp.driverservice.persistence.repository.DriverRepository;
+import by.arvisit.cabapp.driverservice.persistence.util.DriverSpecs;
+import by.arvisit.cabapp.exceptionhandlingstarter.exception.UsernameAlreadyExistsException;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DriverServiceImplTest {
+
+    @InjectMocks
+    private DriverServiceImpl driverService;
+    @Mock
+    private DriverRepository driverRepository;
+    @Mock
+    private DriverMapper driverMapper;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private DriverSpecs driverSpecs;
+
+    @Test
+    void shouldReturnContainerWithDriverResponseDto_whenGetDrivers() {
+        DriverResponseDto driverResponseDto = getDriverResponseDto().build();
+        Driver driver = getDriver().build();
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        List<Driver> drivers = List.of(driver);
+        Page<Driver> driversPage = new PageImpl<>(drivers);
+        Specification<Driver> spec = (root, query, cb) -> cb.conjunction();
+
+        when(driverSpecs.getAllByFilter(any()))
+                .thenReturn(spec);
+        when(driverRepository.findAll(spec, pageable))
+                .thenReturn(driversPage);
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.count(spec))
+                .thenReturn((long) drivers.size());
+
+        assertThat(driverService.getDrivers(pageable, any()))
+                .isEqualTo(getDriverResponseDtoInListContainer().build());
+    }
+
+    @Test
+    void shouldReturnContainerWithAvailableDriverResponseDto_whenGetAvailableDrivers() {
+        DriverResponseDto driverResponseDto = getDriverResponseDto().build();
+        Driver driver = getDriver().build();
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        List<Driver> drivers = List.of(driver);
+
+        when(driverRepository.findByIsAvailableTrue(pageable))
+                .thenReturn(drivers);
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.countByIsAvailableTrue())
+                .thenReturn((long) drivers.size());
+
+        assertThat(driverService.getAvailableDrivers(pageable))
+                .isEqualTo(getDriverResponseDtoInListContainer().build());
+
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenGetDriverByExistingId() {
+        Driver driver = getDriver().build();
+        DriverResponseDto driverResponseDto = getDriverResponseDto().build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(driver));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+
+        assertThat(driverService.getDriverById(DEFAULT_DRIVER_ID_STRING))
+                .isEqualTo(driverResponseDto);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetDriverByNonExistingId() {
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> driverService.getDriverById(DEFAULT_DRIVER_ID_STRING))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenGetDriverByExistingEmail() {
+        Driver driver = getDriver().build();
+        DriverResponseDto driverResponseDto = getDriverResponseDto().build();
+
+        when(driverRepository.findByEmail(anyString()))
+                .thenReturn(Optional.of(driver));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+
+        assertThat(driverService.getDriverByEmail(DEFAULT_DRIVER_EMAIL))
+                .isEqualTo(driverResponseDto);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetDriverByNonExistingEmail() {
+        when(driverRepository.findByEmail(anyString()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> driverService.getDriverByEmail(DEFAULT_DRIVER_EMAIL))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenSaveDriverWithNotInUseEmail() {
+        Driver driver = getDriver().build();
+        DriverRequestDto driverRequestDto = getDriverRequestDto().build();
+        DriverResponseDto driverResponseDto = getDriverResponseDto().build();
+
+        when(driverRepository.existsByEmail(anyString()))
+                .thenReturn(false);
+        when(driverMapper.fromRequestDtoToEntity(any(DriverRequestDto.class)))
+                .thenReturn(driver);
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.save(any(Driver.class)))
+                .thenReturn(driver);
+
+        assertThat(driverService.save(driverRequestDto))
+                .isEqualTo(driverResponseDto);
+    }
+
+    @Test
+    void shouldThrowUsernameAlreadyExistsException_whenSaveDriverWithInUseEmail() {
+        DriverRequestDto driverRequestDto = getDriverRequestDto().build();
+
+        when(driverRepository.existsByEmail(anyString()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> driverService.save(driverRequestDto))
+                .isInstanceOf(UsernameAlreadyExistsException.class);
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenUpdateExistingDriverWithSameEmailAndNewName() {
+        DriverRequestDto driverRequestDto = getDriverRequestDto()
+                .withName(NEW_DRIVER_NAME)
+                .build();
+        Driver existingDriver = getDriver().build();
+        Driver savedDriver = getDriver()
+                .withName(NEW_DRIVER_NAME)
+                .build();
+        DriverResponseDto driverResponseDto = getDriverResponseDto()
+                .withName(NEW_DRIVER_NAME)
+                .build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(existingDriver));
+        when(driverRepository.existsByEmail(anyString()))
+                .thenReturn(true);
+        doNothing().when(driverMapper)
+                .updateEntityWithRequestDto(any(DriverRequestDto.class), any(Driver.class));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.save(any(Driver.class)))
+                .thenReturn(savedDriver);
+
+        assertThat(driverService.update(DEFAULT_DRIVER_ID_STRING, driverRequestDto))
+                .isEqualTo(driverResponseDto);
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenUpdateExistingDriverWithNewNotInUseEmail() {
+        DriverRequestDto driverRequestDto = getDriverRequestDto()
+                .withEmail(NEW_DRIVER_EMAIL)
+                .build();
+        Driver existingDriver = getDriver().build();
+        Driver savedDriver = getDriver()
+                .withEmail(NEW_DRIVER_EMAIL)
+                .build();
+        DriverResponseDto driverResponseDto = getDriverResponseDto()
+                .withEmail(NEW_DRIVER_EMAIL)
+                .build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(existingDriver));
+        when(driverRepository.existsByEmail(anyString()))
+                .thenReturn(false);
+        doNothing().when(driverMapper)
+                .updateEntityWithRequestDto(any(DriverRequestDto.class), any(Driver.class));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.save(any(Driver.class)))
+                .thenReturn(savedDriver);
+
+        assertThat(driverService.update(DEFAULT_DRIVER_ID_STRING, driverRequestDto))
+                .isEqualTo(driverResponseDto);
+    }
+
+    @Test
+    void shouldThrowUsernameAlreadyExistsException_whenUpdateExistingDriverWithInUseEmailOfAnotherDriver() {
+        DriverRequestDto driverRequestDto = getDriverRequestDto()
+                .withEmail(NEW_DRIVER_EMAIL)
+                .build();
+        Driver existingDriver = getDriver().build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(existingDriver));
+        when(driverRepository.existsByEmail(anyString()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> driverService.update(DEFAULT_DRIVER_ID_STRING, driverRequestDto))
+                .isInstanceOf(UsernameAlreadyExistsException.class);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenUpdateNonExistingDriver() {
+        DriverRequestDto driverRequestDto = getDriverRequestDto().build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> driverService.update(DEFAULT_DRIVER_ID_STRING, driverRequestDto))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldCallRepository_whenUpdateAvailabilityOfExistingDriverWithNewValue() {
+        boolean oldValue = true;
+        Driver existingDriver = getDriver()
+                .withIsAvailable(oldValue)
+                .build();
+        boolean newValue = false;
+        DriverResponseDto driverResponseDto = getDriverResponseDto()
+                .withIsAvailable(newValue)
+                .build();
+        Driver updatedDriver = getDriver()
+                .withIsAvailable(newValue)
+                .build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(existingDriver));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+        when(driverRepository.save(any(Driver.class)))
+                .thenReturn(updatedDriver);
+
+        DriverResponseDto actualResponseDto = driverService.updateAvailability(DEFAULT_DRIVER_ID_STRING, newValue);
+
+        verify(driverRepository, times(1)).save(existingDriver);
+
+        assertThat(actualResponseDto.isAvailable())
+                .isEqualTo(newValue);
+        assertThat(oldValue)
+                .isNotEqualTo(newValue);
+    }
+
+    @Test
+    void shouldNotCallRepository_whenUpdateAvailabilityOfExistingDriverWithSameValue() {
+        boolean oldValue = true;
+        Driver existingDriver = getDriver()
+                .withIsAvailable(oldValue)
+                .build();
+        boolean newValue = true;
+        DriverResponseDto driverResponseDto = getDriverResponseDto()
+                .withIsAvailable(newValue)
+                .build();
+
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(existingDriver));
+        when(driverMapper.fromEntityToResponseDto(any(Driver.class)))
+                .thenReturn(driverResponseDto);
+
+        DriverResponseDto actualResponseDto = driverService.updateAvailability(DEFAULT_DRIVER_ID_STRING, newValue);
+
+        verify(driverRepository, times(0)).save(existingDriver);
+
+        assertThat(actualResponseDto.isAvailable())
+                .isEqualTo(newValue);
+        assertThat(oldValue)
+                .isEqualTo(newValue);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldThrowEntityNotFoundException_whenUpdateAvailabilityOfNonExistingDriver(boolean value) {
+        when(driverRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> driverService.updateAvailability(DEFAULT_DRIVER_ID_STRING, value))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldThrowNothing_whenDeleteExistingDriver() {
+        when(driverRepository.existsById(any(UUID.class)))
+                .thenReturn(true);
+        doNothing().when(driverRepository)
+                .deleteById(any(UUID.class));
+
+        assertThatNoException()
+                .isThrownBy(() -> driverService.delete(DEFAULT_DRIVER_ID_STRING));
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenDeleteNonExistingDriver() {
+        when(driverRepository.existsById(any(UUID.class)))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> driverService.delete(DEFAULT_DRIVER_ID_STRING))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
@@ -1,0 +1,153 @@
+package by.arvisit.cabapp.driverservice.util;
+
+import java.util.List;
+import java.util.UUID;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.CarManufacturerResponseDto;
+import by.arvisit.cabapp.driverservice.dto.CarRequestDto;
+import by.arvisit.cabapp.driverservice.dto.CarResponseDto;
+import by.arvisit.cabapp.driverservice.dto.ColorResponseDto;
+import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
+import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
+import by.arvisit.cabapp.driverservice.persistence.model.Car;
+import by.arvisit.cabapp.driverservice.persistence.model.CarManufacturer;
+import by.arvisit.cabapp.driverservice.persistence.model.Color;
+import by.arvisit.cabapp.driverservice.persistence.model.Driver;
+
+public final class DriverTestData {
+
+    public static final Integer COLOR_ID_WHITE = 1;
+    public static final String COLOR_NAME_WHITE = "White";
+    public static final Integer COLOR_ID_BLACK = 2;
+    public static final String COLOR_NAME_BLACK = "Black";
+    public static final Integer DEFAULT_CAR_MANUFACTURER_ID = 1;
+    public static final String DEFAULT_CAR_MANUFACTURER_NAME = "Toyota";
+    public static final String DEFAULT_CAR_ID_STRING = "8805899c-8fcd-4585-8ccb-1edec54a964a";
+    public static final UUID DEFAULT_CAR_ID_UUID = UUID.fromString(DEFAULT_CAR_ID_STRING);
+    public static final String DEFAULT_CAR_REGISTRATION_NUMBER = "E070CC-4";
+    public static final String DEFAULT_DRIVER_ID_STRING = "a7dd0543-0adc-4ea6-9ca7-7b72065ca011";
+    public static final UUID DEFAULT_DRIVER_ID_UUID = UUID.fromString(DEFAULT_DRIVER_ID_STRING);
+    public static final String DEFAULT_DRIVER_NAME = "Jeremias Olsen";
+    public static final String DEFAULT_DRIVER_EMAIL = "jeremias.olsen@frontiernet.net";
+    public static final String DEFAULT_DRIVER_CARD_NUMBER = "1522613953683617";
+    public static final Boolean DEFAULT_IS_AVAILABLE = true;
+    public static final Integer DEFAULT_PAGEABLE_SIZE = 10;
+    public static final String UNSORTED = "UNSORTED";
+    public static final String NEW_DRIVER_NAME = "John Doe";
+    public static final String NEW_DRIVER_EMAIL = "john.doe@mail.com";
+
+    private DriverTestData() {
+    }
+
+    public static Color.ColorBuilder getColor() {
+        return Color.builder()
+                .withId(COLOR_ID_WHITE)
+                .withName(COLOR_NAME_WHITE);
+    }
+
+    public static ColorResponseDto.ColorResponseDtoBuilder getColorResponseDto() {
+        return ColorResponseDto.builder()
+                .withId(COLOR_ID_WHITE)
+                .withName(COLOR_NAME_WHITE);
+    }
+
+    public static CarManufacturer.CarManufacturerBuilder getCarManufacturer() {
+        return CarManufacturer.builder()
+                .withId(DEFAULT_CAR_MANUFACTURER_ID)
+                .withName(DEFAULT_CAR_MANUFACTURER_NAME);
+    }
+
+    public static CarManufacturerResponseDto.CarManufacturerResponseDtoBuilder getCarManufacturerResponseDto() {
+        return CarManufacturerResponseDto.builder()
+                .withId(DEFAULT_CAR_MANUFACTURER_ID)
+                .withName(DEFAULT_CAR_MANUFACTURER_NAME);
+    }
+
+    public static Car.CarBuilder getCar() {
+        return Car.builder()
+                .withId(DEFAULT_CAR_ID_UUID)
+                .withRegistrationNumber(DEFAULT_CAR_REGISTRATION_NUMBER)
+                .withColor(getColor().build())
+                .withManufacturer(getCarManufacturer().build());
+    }
+
+    public static CarRequestDto.CarRequestDtoBuilder getCarRequestDto() {
+        return CarRequestDto.builder()
+                .withManufacturerId(DEFAULT_CAR_MANUFACTURER_ID)
+                .withColorId(COLOR_ID_WHITE)
+                .withRegistrationNumber(DEFAULT_CAR_REGISTRATION_NUMBER);
+    }
+
+    public static CarResponseDto.CarResponseDtoBuilder getCarResponseDto() {
+        return CarResponseDto.builder()
+                .withId(DEFAULT_CAR_ID_STRING)
+                .withManufacturer(getCarManufacturerResponseDto().build())
+                .withColor(getColorResponseDto().build())
+                .withRegistrationNumber(DEFAULT_CAR_REGISTRATION_NUMBER);
+    }
+
+    public static Driver.DriverBuilder getDriver() {
+        return Driver.builder()
+                .withId(DEFAULT_DRIVER_ID_UUID)
+                .withName(DEFAULT_DRIVER_NAME)
+                .withEmail(DEFAULT_DRIVER_EMAIL)
+                .withCardNumber(DEFAULT_DRIVER_CARD_NUMBER)
+                .withCar(getCar().build())
+                .withIsAvailable(DEFAULT_IS_AVAILABLE);
+    }
+
+    public static DriverRequestDto.DriverRequestDtoBuilder getDriverRequestDto() {
+        return DriverRequestDto.builder()
+                .withName(DEFAULT_DRIVER_NAME)
+                .withEmail(DEFAULT_DRIVER_EMAIL)
+                .withCardNumber(DEFAULT_DRIVER_CARD_NUMBER)
+                .withCar(getCarRequestDto().build());
+    }
+
+    public static DriverResponseDto.DriverResponseDtoBuilder getDriverResponseDto() {
+        return DriverResponseDto.builder()
+                .withId(DEFAULT_DRIVER_ID_STRING)
+                .withName(DEFAULT_DRIVER_NAME)
+                .withEmail(DEFAULT_DRIVER_EMAIL)
+                .withCardNumber(DEFAULT_DRIVER_CARD_NUMBER)
+                .withCar(getCarResponseDto().build())
+                .withIsAvailable(DEFAULT_IS_AVAILABLE);
+    }
+
+    public static ListContainerResponseDto.ListContainerResponseDtoBuilder<DriverResponseDto> getDriverResponseDtoInListContainer() {
+        return ListContainerResponseDto.<DriverResponseDto>builder()
+                .withCurrentPage(0)
+                .withSize(DEFAULT_PAGEABLE_SIZE)
+                .withLastPage(0)
+                .withSort(UNSORTED)
+                .withValues(List.of(getDriverResponseDto().build()));
+    }
+
+    public static ListContainerResponseDto.ListContainerResponseDtoBuilder<ColorResponseDto> getColorResponseDtoInListContainer() {
+        return ListContainerResponseDto.<ColorResponseDto>builder()
+                .withCurrentPage(0)
+                .withSize(DEFAULT_PAGEABLE_SIZE)
+                .withLastPage(0)
+                .withSort(UNSORTED)
+                .withValues(List.of(getColorResponseDto().build()));
+    }
+
+    public static ListContainerResponseDto.ListContainerResponseDtoBuilder<CarManufacturerResponseDto> getCarManufacturerResponseDtoInListContainer() {
+        return ListContainerResponseDto.<CarManufacturerResponseDto>builder()
+                .withCurrentPage(0)
+                .withSize(DEFAULT_PAGEABLE_SIZE)
+                .withLastPage(0)
+                .withSort(UNSORTED)
+                .withValues(List.of(getCarManufacturerResponseDto().build()));
+    }
+
+    public static ListContainerResponseDto.ListContainerResponseDtoBuilder<CarResponseDto> getCarResponseDtoInListContainer() {
+        return ListContainerResponseDto.<CarResponseDto>builder()
+                .withCurrentPage(0)
+                .withSize(DEFAULT_PAGEABLE_SIZE)
+                .withLastPage(0)
+                .withSort(UNSORTED)
+                .withValues(List.of(getCarResponseDto().build()));
+    }
+}

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
@@ -36,6 +36,21 @@ public final class DriverTestData {
     public static final String UNSORTED = "UNSORTED";
     public static final String NEW_DRIVER_NAME = "John Doe";
     public static final String NEW_DRIVER_EMAIL = "john.doe@mail.com";
+    public static final String ENCODING_UTF_8 = "UTF-8";
+    public static final String URL_COLORS = "/api/v1/colors";
+    public static final String URL_CAR_MANUFACTURERS = "/api/v1/car-manufacturers";
+    public static final String URL_CARS = "/api/v1/cars";
+    public static final String URL_CARS_ID_TEMPLATE = "/api/v1/cars/{id}";
+    public static final String URL_DRIVERS = "/api/v1/drivers";
+    public static final String URL_AVAILABLE_DRIVERS = "/api/v1/drivers/available";
+    public static final String URL_DRIVERS_ID_TEMPLATE = "/api/v1/drivers/{id}";
+    public static final String URL_DRIVERS_ID_AVAILABILITY_TEMPLATE = "/api/v1/drivers/{id}/availability";
+    public static final String URL_DRIVERS_EMAIL_TEMPLATE = "/api/v1/drivers/by-email/{email}";
+    public static final String URL_DRIVERS_PARAM_VALUE_TEMPLATE = "/api/v1/drivers?{param}={value}";
+    public static final String NOT_ALLOWED_REQUEST_PARAM = "driverId";
+    public static final String NAME_REQUEST_PARAM = "name";
+    public static final String IS_AVAILABLE_REQUEST_PARAM = "isAvailable";
+    public static final String IS_AVAILABLE_KEY = "isAvailable";
 
     private DriverTestData() {
     }

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
@@ -1,6 +1,8 @@
 package by.arvisit.cabapp.driverservice.util;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -11,6 +13,7 @@ import by.arvisit.cabapp.driverservice.dto.CarResponseDto;
 import by.arvisit.cabapp.driverservice.dto.ColorResponseDto;
 import by.arvisit.cabapp.driverservice.dto.DriverRequestDto;
 import by.arvisit.cabapp.driverservice.dto.DriverResponseDto;
+import by.arvisit.cabapp.driverservice.dto.DriversFilterParams;
 import by.arvisit.cabapp.driverservice.persistence.model.Car;
 import by.arvisit.cabapp.driverservice.persistence.model.CarManufacturer;
 import by.arvisit.cabapp.driverservice.persistence.model.Color;
@@ -51,6 +54,12 @@ public final class DriverTestData {
     public static final String NOT_ALLOWED_REQUEST_PARAM = "driverId";
     public static final String NAME_REQUEST_PARAM = "name";
     public static final String IS_AVAILABLE_REQUEST_PARAM = "isAvailable";
+    public static final String CAR_MANUFACTURER_NAME_REQUEST_PARAM = "carManufacturerName";
+    public static final String EMAIL_REQUEST_PARAM = "email";
+    public static final String NAME_TO_FILTER = "jack";
+    public static final String EMAIL_TO_FILTER = "com";
+    public static final String IS_AVAILABLE_TO_FILTER = "true";
+    public static final String CAR_MANUFACTURER_NAME_TO_FILTER = "Audi";
     public static final String IS_AVAILABLE_KEY = "isAvailable";
 
     private DriverTestData() {
@@ -165,6 +174,31 @@ public final class DriverTestData {
                 .withLastPage(0)
                 .withSort(UNSORTED)
                 .withValues(List.of(getCarResponseDto().build()));
+    }
+
+    public static DriversFilterParams.DriversFilterParamsBuilder getEmptyDriversFilterParams() {
+        return DriversFilterParams.builder()
+                .withEmail(null)
+                .withName(null)
+                .withIsAvailable(null)
+                .withCarManufacturerName(null);
+    }
+
+    public static DriversFilterParams.DriversFilterParamsBuilder getFilledDriversFilterParams() {
+        return DriversFilterParams.builder()
+                .withEmail(EMAIL_TO_FILTER)
+                .withName(NAME_TO_FILTER)
+                .withIsAvailable(Boolean.parseBoolean(IS_AVAILABLE_TO_FILTER))
+                .withCarManufacturerName(CAR_MANUFACTURER_NAME_TO_FILTER);
+    }
+
+    public static Map<String, String> getRequestParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put(NAME_REQUEST_PARAM, NAME_TO_FILTER);
+        params.put(EMAIL_REQUEST_PARAM, EMAIL_TO_FILTER);
+        params.put(IS_AVAILABLE_REQUEST_PARAM, IS_AVAILABLE_TO_FILTER);
+        params.put(CAR_MANUFACTURER_NAME_REQUEST_PARAM, CAR_MANUFACTURER_NAME_TO_FILTER);
+        return params;
     }
 
     public static Stream<String> blankStrings() {

--- a/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
+++ b/cab-app-driver-service/src/test/java/by/arvisit/cabapp/driverservice/util/DriverTestData.java
@@ -2,6 +2,7 @@ package by.arvisit.cabapp.driverservice.util;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
 import by.arvisit.cabapp.driverservice.dto.CarManufacturerResponseDto;
@@ -164,5 +165,34 @@ public final class DriverTestData {
                 .withLastPage(0)
                 .withSort(UNSORTED)
                 .withValues(List.of(getCarResponseDto().build()));
+    }
+
+    public static Stream<String> blankStrings() {
+        return Stream.of("", "   ", null);
+    }
+
+    public static Stream<String> malformedEmails() {
+        return Stream.of("   ", "not-email", "not-email.mail.com", "not email", "not email@mail.com");
+    }
+
+    public static Stream<String> malformedCardNumbers() {
+        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444");
+    }
+
+    public static Stream<String> malformedCarRegistrationNumbers() {
+        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444", "A000AA-1", "0000YA-1",
+                "0000AA1", "0000AA_1", "0000AA-0", "0000AA-9", "E000YA-1", "E000AA1", "E000AA_1", "E000AA-0",
+                "E000AA-9");
+    }
+
+    public static Stream<String> malformedUUIDs() {
+        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
+                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444");
+    }
+
+    public static Stream<String> malformedBooleans() {
+        return Stream.of("", "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444", "truth", "lies", "trui", "falce");
     }
 }


### PR DESCRIPTION
- **Convert DriverMapper to interface**
- **Add test data**
- **Add mapper unit tests**
- **Add service unit tests**
- **Add profile for feign client to exclude from WebMvcTest**
- **Remove unreachable constraint NotNull for required request body**
- **Add missed constraints**
- **Harmonize used/unused messages**
- **Add jacoco to pom.xml**
- **Add test data for WebMvcTests**
- **Add controller unit tests**
- **Correct test names for CONFLICT status in driver-service**
- **Move methods with sources for parameterized tests to util test data**
- **Remove unused constant**
- **Modify tests according to DriversFilterParams usage**
