### PR TITLE
test/021 unit tests payment service

### DIFF
--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectDriverClient.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectDriverClient.java
@@ -1,11 +1,13 @@
 package by.arvisit.cabapp.paymentservice.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import by.arvisit.cabapp.common.dto.driver.DriverResponseDto;
 
+@Profile({ "dev", "itest" })
 @FeignClient(name = "cab-app-driver-service", url = "${spring.settings.cab-app-driver-service.uri}",
         configuration = CabAppFeignClientConfiguration.class)
 public interface DirectDriverClient extends DriverClient {

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectPassengerClient.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectPassengerClient.java
@@ -1,11 +1,13 @@
 package by.arvisit.cabapp.paymentservice.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import by.arvisit.cabapp.common.dto.passenger.PassengerResponseDto;
 
+@Profile({ "dev", "itest" })
 @FeignClient(value = "cab-app-passenger-service", url = "${spring.settings.cab-app-passenger-service.uri}",
         configuration = CabAppFeignClientConfiguration.class)
 public interface DirectPassengerClient extends PassengerClient {

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectRideClient.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/client/DirectRideClient.java
@@ -1,11 +1,13 @@
 package by.arvisit.cabapp.paymentservice.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
 
+@Profile({ "dev", "itest" })
 @FeignClient(name = "cab-app-rides-service", url = "${spring.settings.cab-app-rides-service.uri}",
         configuration = CabAppFeignClientConfiguration.class)
 public interface DirectRideClient extends RideClient {

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/dto/DriverPaymentResponseDto.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/dto/DriverPaymentResponseDto.java
@@ -1,6 +1,7 @@
 package by.arvisit.cabapp.paymentservice.dto;
 
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 
 import lombok.Builder;
 
@@ -12,6 +13,6 @@ public record DriverPaymentResponseDto(
         String operation,
         String cardNumber,
         String status,
-        String timestamp) {
+        ZonedDateTime timestamp) {
 
 }

--- a/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentMapper.java
+++ b/cab-app-payment-service/src/main/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentMapper.java
@@ -13,6 +13,7 @@ import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
         builder = @Builder(disableBuilder = true))
 public interface PassengerPaymentMapper {
 
+    @Mapping(target = "feeAmount", ignore = true)
     @Mapping(target = "timestamp", ignore = true)
     @Mapping(target = "status", ignore = true)
     PassengerPayment fromRequestDtoToEntity(PassengerPaymentRequestDto dto);

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/DriverPaymentControllerTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/DriverPaymentControllerTest.java
@@ -1,0 +1,608 @@
+package by.arvisit.cabapp.paymentservice.controller;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_ID_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_PAYMENT_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.NOT_ALLOWED_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.NOT_VALID_OPERATION;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_NEGATIVE_AMOUNT;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.TIMESTAMP_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_DRIVER_PAYMENTS;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_DRIVER_PAYMENTS_ID_TEMPLATE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverAccountBalanceResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+import by.arvisit.cabapp.paymentservice.dto.DriverAccountBalanceResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.persistence.model.OperationTypeEnum;
+import by.arvisit.cabapp.paymentservice.service.DriverPaymentService;
+import jakarta.persistence.EntityNotFoundException;
+
+@WebMvcTest(controllers = DriverPaymentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class DriverPaymentControllerTest {
+
+    private static final String UNPARSEABLE_DATE_MESSAGE = "Unparseable date values detected";
+    private static final String UNPARSEABLE_UUID_MESSAGE = "Unparseable UUID values detected";
+    private static final String REQUEST_PARAMS_VALUE_BLANK_MESSAGE = "must not be blank";
+    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, operation, driverId, timestamp]";
+    private static final String OPERATION_TYPE_NOT_VALID_MESSAGE = "Operation type should be WITHDRAWAL or REPAYMENT";
+    private static final String OPERATION_BLANK_MESSAGE = "Operation should not be blank";
+    private static final String CARD_NUMBER_NOT_MATCH_PATTERN = "Card number should consist of 16 digits";
+    private static final String CARD_NUMBER_BLANK_MESSAGE = "Card number should not be blank";
+    private static final String PAYMENT_AMOUNT_NEGATIVE_MESSAGE = "Payment amount value should be greater than 0";
+    private static final String PAYMENT_AMOUNT_NULL_MESSAGE = "Payment amount value should not be null";
+    private static final String DRIVER_ID_NULL_MESSAGE = "Driver id should not be null";
+    private static final String MALFORMED_UUID_MESSAGE = "must be a valid UUID";
+    private static final String TIMESTAMP_FIELD = "timestamp";
+    private static final String IN_LIST_CONTAINER_TIMESTAMP_FIELD = "values.timestamp";
+    private static final String EMPTY_STRING = "";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private DriverPaymentService driverPaymentService;
+
+    @Nested
+    class SaveDriverPayment {
+
+        @Test
+        void shouldReturn201_whenValidInput() throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenValidInput() throws Exception {
+            DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+            when(driverPaymentService.save(any(DriverPaymentRequestDto.class)))
+                    .thenReturn(responseDto);
+
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            verify(driverPaymentService, times(1)).save(requestDto);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverPaymentResponseDto result = objectMapper.readValue(actualResponseBody,
+                    DriverPaymentResponseDto.class);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayment_whenValidInput() throws Exception {
+            DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+            when(driverPaymentService.save(any(DriverPaymentRequestDto.class)))
+                    .thenReturn(responseDto);
+
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldReturn409_whenNotVerifiedInput() throws Exception {
+            when(driverPaymentService.save(any(DriverPaymentRequestDto.class)))
+                    .thenThrow(IllegalStateException.class);
+
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+
+        @Test
+        void shouldReturn400_whenNullDriverId() throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withDriverId(null)
+                    .build();
+
+            String expectedContent = DRIVER_ID_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedDriverId(String driverId) throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withDriverId(driverId)
+                    .build();
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullAmount() throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withAmount(null)
+                    .build();
+
+            String expectedContent = PAYMENT_AMOUNT_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNegativeAmount() throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withAmount(PASSENGER_PAYMENT_NEGATIVE_AMOUNT)
+                    .build();
+
+            String expectedContent = PAYMENT_AMOUNT_NEGATIVE_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#blankStrings")
+        void shouldReturn400_whenBlankCardNumber(String cardNumber) throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withCardNumber(cardNumber)
+                    .build();
+
+            String expectedContent = CARD_NUMBER_BLANK_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedCardNumbers")
+        void shouldReturn400_whenCardNumberNotMatchPattern(String cardNumber) throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withCardNumber(cardNumber)
+                    .build();
+
+            String expectedContent = CARD_NUMBER_NOT_MATCH_PATTERN;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#blankStrings")
+        void shouldReturn400_whenBlankOperation(String operation) throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withOperation(operation)
+                    .build();
+
+            String expectedContent = OPERATION_BLANK_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNotValidOperation() throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withOperation(NOT_VALID_OPERATION)
+                    .build();
+
+            String expectedContent = OPERATION_TYPE_NOT_VALID_MESSAGE;
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @EnumSource(OperationTypeEnum.class)
+        void shouldReturn201_whenValidOperation(OperationTypeEnum operation) throws Exception {
+            DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto()
+                    .withOperation(operation.toString())
+                    .build();
+
+            mockMvc.perform(post(URL_DRIVER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    @Nested
+    class GetPaymentById {
+
+        @Test
+        void shouldReturn200_whenExistingId() throws Exception {
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, DRIVER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+
+            when(driverPaymentService.getPaymentById(anyString()))
+                    .thenReturn(responseDto);
+
+            String paymentId = DRIVER_PAYMENT_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, paymentId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverPaymentService, times(1)).getPaymentById(paymentId);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverPaymentResponseDto result = objectMapper.readValue(actualResponseBody,
+                    DriverPaymentResponseDto.class);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayment_whenExistingId() throws Exception {
+            DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+
+            when(driverPaymentService.getPaymentById(anyString()))
+                    .thenReturn(responseDto);
+
+            String paymentId = DRIVER_PAYMENT_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, paymentId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, id)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            when(driverPaymentService.getPaymentById(anyString()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, DRIVER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class GetPayments {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_ID_TEMPLATE, DRIVER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverPaymentResponseDto> responseDto = getListContainerForResponse(
+                    DriverPaymentResponseDto.class)
+                    .withValues(List.of(getDriverPaymentResponseDto().build()))
+                    .build();
+
+            when(driverPaymentService.getPayments(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            verify(driverPaymentService, times(1)).getPayments(pageable, Collections.emptyMap());
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<DriverPaymentResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<DriverPaymentResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(IN_LIST_CONTAINER_TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayments_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<DriverPaymentResponseDto> responseDto = getListContainerForResponse(
+                    DriverPaymentResponseDto.class)
+                    .withValues(List.of(getDriverPaymentResponseDto().build()))
+                    .build();
+
+            when(driverPaymentService.getPayments(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldReturn400_whenNotAllowedRequestParam() throws Exception {
+            String expectedContent = REQUEST_PARAMS_NOT_ALLOWED_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE, NOT_ALLOWED_REQUEST_PARAM, DRIVER_ID_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenBlankRequestParamValue() throws Exception {
+            String expectedContent = REQUEST_PARAMS_VALUE_BLANK_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE, DRIVER_ID_REQUEST_PARAM, EMPTY_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedDates")
+        void shouldReturn400_whenNotParseableDateForDateTypeRequestParam(String value) throws Exception {
+            String expectedContent = UNPARSEABLE_DATE_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE, TIMESTAMP_REQUEST_PARAM, value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenNotParseableUUIDForUUIDTypeRequestParam(String value) throws Exception {
+            String expectedContent = UNPARSEABLE_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE, DRIVER_ID_REQUEST_PARAM, value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+    }
+
+    @Nested
+    class GetDriverAccountBalance {
+
+        @Test
+        void shouldReturn200_whenExistingId() throws Exception {
+            DriverAccountBalanceResponseDto responseDto = getDriverAccountBalanceResponseDto().build();
+
+            when(driverPaymentService.getDriverAccountBalance(anyString()))
+                    .thenReturn(responseDto);
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE, DRIVER_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            DriverAccountBalanceResponseDto responseDto = getDriverAccountBalanceResponseDto().build();
+
+            when(driverPaymentService.getDriverAccountBalance(anyString()))
+                    .thenReturn(responseDto);
+
+            String driverId = DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE, driverId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(driverPaymentService, times(1)).getDriverAccountBalance(driverId);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            DriverAccountBalanceResponseDto result = objectMapper.readValue(actualResponseBody,
+                    DriverAccountBalanceResponseDto.class);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayment_whenExistingId() throws Exception {
+            DriverAccountBalanceResponseDto responseDto = getDriverAccountBalanceResponseDto().build();
+
+            when(driverPaymentService.getDriverAccountBalance(anyString()))
+                    .thenReturn(responseDto);
+
+            String driverId = DRIVER_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE, driverId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedMessage = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE, id)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedMessage)));
+        }
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/DriverPaymentControllerTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/DriverPaymentControllerTest.java
@@ -68,7 +68,7 @@ class DriverPaymentControllerTest {
     private static final String UNPARSEABLE_DATE_MESSAGE = "Unparseable date values detected";
     private static final String UNPARSEABLE_UUID_MESSAGE = "Unparseable UUID values detected";
     private static final String REQUEST_PARAMS_VALUE_BLANK_MESSAGE = "must not be blank";
-    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, operation, driverId, timestamp]";
+    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Invalid input parameters: noSuchParam. Valid parameters are: size, driverId, page, sort, operation, status, timestamp";
     private static final String OPERATION_TYPE_NOT_VALID_MESSAGE = "Operation type should be WITHDRAWAL or REPAYMENT";
     private static final String OPERATION_BLANK_MESSAGE = "Operation should not be blank";
     private static final String CARD_NUMBER_NOT_MATCH_PATTERN = "Card number should consist of 16 digits";

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
@@ -65,7 +65,7 @@ class PassengerPaymentControllerTest {
     private static final String UNPARSEABLE_DATE_MESSAGE = "Unparseable date values detected";
     private static final String UNPARSEABLE_UUID_MESSAGE = "Unparseable UUID values detected";
     private static final String REQUEST_PARAMS_VALUE_BLANK_MESSAGE = "must not be blank";
-    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, paymentMethod, passengerId, driverId, timestamp]";
+    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, paymentMethod, passengerId, driverId, rideId, timestamp]";
     private static final String PAYMENT_METHOD_NOT_VALID_MESSAGE = "Payment method should be BANK_CARD or CASH";
     private static final String PAYMENT_METHOD_BLANK_MESSAGE = "Payment method should not be blank";
     private static final String CARD_NUMBER_NOT_MATCH_PATTERN = "Card number should consist of 16 digits";

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
@@ -65,7 +65,7 @@ class PassengerPaymentControllerTest {
     private static final String UNPARSEABLE_DATE_MESSAGE = "Unparseable date values detected";
     private static final String UNPARSEABLE_UUID_MESSAGE = "Unparseable UUID values detected";
     private static final String REQUEST_PARAMS_VALUE_BLANK_MESSAGE = "must not be blank";
-    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, paymentMethod, passengerId, driverId, rideId, timestamp]";
+    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Invalid input parameters: noSuchParam. Valid parameters are: size, driverId, paymentMethod, passengerId, page, sort, rideId, status, timestamp";
     private static final String PAYMENT_METHOD_NOT_VALID_MESSAGE = "Payment method should be BANK_CARD or CASH";
     private static final String PAYMENT_METHOD_BLANK_MESSAGE = "Payment method should not be blank";
     private static final String CARD_NUMBER_NOT_MATCH_PATTERN = "Card number should consist of 16 digits";

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/controller/PassengerPaymentControllerTest.java
@@ -1,0 +1,633 @@
+package by.arvisit.cabapp.paymentservice.controller;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.ENCODING_UTF_8;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.NOT_ALLOWED_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.NOT_VALID_PAYMENT_METHOD;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_CARD_NUMBER;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_ID_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_NEGATIVE_AMOUNT;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.TIMESTAMP_REQUEST_PARAM;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_PASSENGER_PAYMENTS;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_PASSENGER_PAYMENTS_ID_TEMPLATE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.exceptionhandlingstarter.handler.GlobalExceptionHandlerAdvice;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.persistence.model.PaymentMethodEnum;
+import by.arvisit.cabapp.paymentservice.service.PassengerPaymentService;
+import jakarta.persistence.EntityNotFoundException;
+
+@WebMvcTest(controllers = PassengerPaymentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerAdvice.class)
+class PassengerPaymentControllerTest {
+
+    private static final String UNPARSEABLE_DATE_MESSAGE = "Unparseable date values detected";
+    private static final String UNPARSEABLE_UUID_MESSAGE = "Unparseable UUID values detected";
+    private static final String REQUEST_PARAMS_VALUE_BLANK_MESSAGE = "must not be blank";
+    private static final String REQUEST_PARAMS_NOT_ALLOWED_MESSAGE = "Only specified request parameters are allowed: [page, size, sort, status, paymentMethod, passengerId, driverId, timestamp]";
+    private static final String PAYMENT_METHOD_NOT_VALID_MESSAGE = "Payment method should be BANK_CARD or CASH";
+    private static final String PAYMENT_METHOD_BLANK_MESSAGE = "Payment method should not be blank";
+    private static final String CARD_NUMBER_NOT_MATCH_PATTERN = "Card number should consist of 16 digits";
+    private static final String PAYMENT_AMOUNT_NEGATIVE_MESSAGE = "Payment amount value should be greater than 0";
+    private static final String PAYMENT_AMOUNT_NULL_MESSAGE = "Payment amount value should not be null";
+    private static final String PASSENGER_ID_NULL_MESSAGE = "Passenger id should not be null";
+    private static final String DRIVER_ID_NULL_MESSAGE = "Driver id should not be null";
+    private static final String RIDE_ID_NULL_MESSAGE = "Ride id should not be null";
+    private static final String MALFORMED_UUID_MESSAGE = "must be a valid UUID";
+    private static final String PAYMENT_METHOD_CARD_BAD_COMBINATION_MESSAGE = "If payment method is CASH then card number should be null. If payment method is BANK_CARD then card number should not be null";
+    private static final String TIMESTAMP_FIELD = "timestamp";
+    private static final String IN_LIST_CONTAINER_TIMESTAMP_FIELD = "values.timestamp";
+    private static final String EMPTY_STRING = "";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private PassengerPaymentService passengerPaymentService;
+
+    @Nested
+    class SavePassengerPayment {
+
+        @Test
+        void shouldReturn201_whenValidInput() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenValidInput() throws Exception {
+            PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+            when(passengerPaymentService.save(any(PassengerPaymentRequestDto.class)))
+                    .thenReturn(responseDto);
+
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            verify(passengerPaymentService, times(1)).save(requestDto);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            PassengerPaymentResponseDto result = objectMapper.readValue(actualResponseBody,
+                    PassengerPaymentResponseDto.class);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayment_whenValidInput() throws Exception {
+            PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+            when(passengerPaymentService.save(any(PassengerPaymentRequestDto.class)))
+                    .thenReturn(responseDto);
+
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+
+            MvcResult mvcResult = mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldReturn409_whenNotVerifiedInput() throws Exception {
+            when(passengerPaymentService.save(any(PassengerPaymentRequestDto.class)))
+                    .thenThrow(IllegalStateException.class);
+
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+
+        @Test
+        void shouldReturn400_whenNullPassengerId() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPassengerId(null)
+                    .build();
+
+            String expectedContent = PASSENGER_ID_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedPassengerId(String passengerId) throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPassengerId(passengerId)
+                    .build();
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullDriverId() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withDriverId(null)
+                    .build();
+
+            String expectedContent = DRIVER_ID_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedDriverId(String driverId) throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withDriverId(driverId)
+                    .build();
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullRideId() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withRideId(null)
+                    .build();
+
+            String expectedContent = RIDE_ID_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedRideId(String rideId) throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withRideId(rideId)
+                    .build();
+
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNullAmount() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withAmount(null)
+                    .build();
+
+            String expectedContent = PAYMENT_AMOUNT_NULL_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNegativeAmount() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withAmount(PASSENGER_PAYMENT_NEGATIVE_AMOUNT)
+                    .build();
+
+            String expectedContent = PAYMENT_AMOUNT_NEGATIVE_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedCardNumbers")
+        void shouldReturn400_whenCardNumberNotMatchPattern(String cardNumber) throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withCardNumber(cardNumber)
+                    .build();
+
+            String expectedContent = CARD_NUMBER_NOT_MATCH_PATTERN;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#blankStrings")
+        void shouldReturn400_whenBlankPaymentMethod(String paymentMethod) throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(paymentMethod)
+                    .build();
+
+            String expectedContent = PAYMENT_METHOD_BLANK_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenNotValidPaymentMethod() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(NOT_VALID_PAYMENT_METHOD)
+                    .build();
+
+            String expectedContent = PAYMENT_METHOD_NOT_VALID_MESSAGE;
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn201_whenBankCardPaymentMethodAndCardNumberUsed() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                    .withCardNumber(PASSENGER_CARD_NUMBER)
+                    .build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void shouldReturn201_whenCashPaymentMethodAndNoCardNumberUsed() throws Exception {
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(PaymentMethodEnum.CASH.toString())
+                    .withCardNumber(null)
+                    .build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void shouldReturn400_whenBankCardPaymentMethodAndNoCardNumberUsed() throws Exception {
+            String expectedContent = PAYMENT_METHOD_CARD_BAD_COMBINATION_MESSAGE;
+
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                    .withCardNumber(null)
+                    .build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenCashPaymentMethodAndCardNumberUsed() throws Exception {
+            String expectedContent = PAYMENT_METHOD_CARD_BAD_COMBINATION_MESSAGE;
+
+            PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto()
+                    .withPaymentMethod(PaymentMethodEnum.CASH.toString())
+                    .withCardNumber(PASSENGER_CARD_NUMBER)
+                    .build();
+
+            mockMvc.perform(post(URL_PASSENGER_PAYMENTS)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+    }
+
+    @Nested
+    class GetPaymentById {
+
+        @Test
+        void shouldReturn200_whenExistingId() throws Exception {
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, PASSENGER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenExistingId() throws Exception {
+            PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+
+            when(passengerPaymentService.getPaymentById(anyString()))
+                    .thenReturn(responseDto);
+
+            String paymentId = PASSENGER_PAYMENT_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, paymentId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            verify(passengerPaymentService, times(1)).getPaymentById(paymentId);
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            PassengerPaymentResponseDto result = objectMapper.readValue(actualResponseBody,
+                    PassengerPaymentResponseDto.class);
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayment_whenExistingId() throws Exception {
+            PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+
+            when(passengerPaymentService.getPaymentById(anyString()))
+                    .thenReturn(responseDto);
+
+            String paymentId = PASSENGER_PAYMENT_ID_STRING;
+            MvcResult mvcResult = mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, paymentId)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenMalformedId(String id) throws Exception {
+            String expectedContent = MALFORMED_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, id)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn404_whenNonExistingId() throws Exception {
+            when(passengerPaymentService.getPaymentById(anyString()))
+                    .thenThrow(EntityNotFoundException.class);
+
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, PASSENGER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class GetPayments {
+
+        @Test
+        void shouldReturn200_whenNoRequestParams() throws Exception {
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_ID_TEMPLATE, PASSENGER_PAYMENT_ID_STRING)
+                    .characterEncoding(ENCODING_UTF_8)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldMapToBusinessModel_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<PassengerPaymentResponseDto> responseDto = getListContainerForResponse(
+                    PassengerPaymentResponseDto.class)
+                    .withValues(List.of(getPassengerPaymentResponseDto().build()))
+                    .build();
+
+            when(passengerPaymentService.getPayments(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_PASSENGER_PAYMENTS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+
+            verify(passengerPaymentService, times(1)).getPayments(pageable, Collections.emptyMap());
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+            ListContainerResponseDto<PassengerPaymentResponseDto> result = objectMapper.readValue(actualResponseBody,
+                    new TypeReference<ListContainerResponseDto<PassengerPaymentResponseDto>>() {
+                    });
+
+            assertThat(result)
+                    .usingRecursiveComparison()
+                    .ignoringFields(IN_LIST_CONTAINER_TIMESTAMP_FIELD)
+                    .isEqualTo(responseDto);
+        }
+
+        @Test
+        void shouldReturnValidPayments_whenNoRequestParams() throws Exception {
+            ListContainerResponseDto<PassengerPaymentResponseDto> responseDto = getListContainerForResponse(
+                    PassengerPaymentResponseDto.class)
+                    .withValues(List.of(getPassengerPaymentResponseDto().build()))
+                    .build();
+
+            when(passengerPaymentService.getPayments(any(Pageable.class), any()))
+                    .thenReturn(responseDto);
+
+            MvcResult mvcResult = mockMvc.perform(get(URL_PASSENGER_PAYMENTS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String actualResponseBody = mvcResult.getResponse().getContentAsString();
+
+            assertThat(actualResponseBody)
+                    .isEqualToIgnoringWhitespace(objectMapper.writeValueAsString(responseDto));
+        }
+
+        @Test
+        void shouldReturn400_whenNotAllowedRequestParam() throws Exception {
+            String expectedContent = REQUEST_PARAMS_NOT_ALLOWED_MESSAGE;
+
+            mockMvc.perform(
+                    get(URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE, NOT_ALLOWED_REQUEST_PARAM, PASSENGER_ID_STRING)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @Test
+        void shouldReturn400_whenBlankRequestParamValue() throws Exception {
+            String expectedContent = REQUEST_PARAMS_VALUE_BLANK_MESSAGE;
+
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE, PASSENGER_ID_REQUEST_PARAM, EMPTY_STRING)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedDates")
+        void shouldReturn400_whenNotParseableDateForDateTypeRequestParam(String value) throws Exception {
+            String expectedContent = UNPARSEABLE_DATE_MESSAGE;
+
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE, TIMESTAMP_REQUEST_PARAM, value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("by.arvisit.cabapp.paymentservice.util.PaymentTestData#malformedUUIDs")
+        void shouldReturn400_whenNotParseableUUIDForUUIDTypeRequestParam(String value) throws Exception {
+            String expectedContent = UNPARSEABLE_UUID_MESSAGE;
+
+            mockMvc.perform(get(URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE, PASSENGER_ID_REQUEST_PARAM, value)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(ENCODING_UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString(expectedContent)));
+        }
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/DriverPaymentMapperTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/DriverPaymentMapperTest.java
@@ -1,0 +1,45 @@
+package by.arvisit.cabapp.paymentservice.mapper;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPayment;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
+
+class DriverPaymentMapperTest {
+
+    private static final String[] FIELDS_TO_IGNORE = { "id", "timestamp", "status" };
+
+    private DriverPaymentMapper driverPaymentMapper = Mappers.getMapper(DriverPaymentMapper.class);
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        DriverPayment entity = getDriverPayment().build();
+
+        DriverPaymentResponseDto actualResponseDto = driverPaymentMapper.fromEntityToResponseDto(entity);
+        DriverPaymentResponseDto expectedResponseDto = getDriverPaymentResponseDto().build();
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+
+    @Test
+    void shouldMapFromRequestDtoToEntity() {
+        DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+
+        DriverPayment actualEntity = driverPaymentMapper.fromRequestDtoToEntity(requestDto);
+        DriverPayment expectedEntity = getDriverPayment().build();
+
+        assertThat(actualEntity)
+                .usingRecursiveComparison()
+                .ignoringFields(FIELDS_TO_IGNORE)
+                .isEqualTo(expectedEntity);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/DriverPaymentsFilterParamsMapperTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/DriverPaymentsFilterParamsMapperTest.java
@@ -1,0 +1,42 @@
+package by.arvisit.cabapp.paymentservice.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentsFilterParams;
+import by.arvisit.cabapp.paymentservice.util.PaymentTestData;
+
+class DriverPaymentsFilterParamsMapperTest {
+
+    private DriverPaymentsFilterParamsMapper filterParamsMapper = new DriverPaymentsFilterParamsMapper();
+
+    @Test
+    void shouldMapFromEmptyMapToFilterParamsDto() {
+        Map<String, String> mapParams = Collections.emptyMap();
+
+        DriverPaymentsFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        DriverPaymentsFilterParams expected = PaymentTestData.getEmptyDriverPaymentsFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldMapFromFilledMapToFilterParamsDto() {
+        Map<String, String> mapParams = PaymentTestData.getDriverPaymentsRequestParams();
+
+        DriverPaymentsFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        DriverPaymentsFilterParams expected = PaymentTestData.getFilledDriverPaymentsFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentMapperTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentMapperTest.java
@@ -1,0 +1,45 @@
+package by.arvisit.cabapp.paymentservice.mapper;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPayment;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
+
+class PassengerPaymentMapperTest {
+
+    private static final String[] FIELDS_TO_IGNORE = { "id", "feeAmount", "timestamp", "status" };
+
+    private PassengerPaymentMapper passengerPaymentMapper = Mappers.getMapper(PassengerPaymentMapper.class);
+
+    @Test
+    void shouldMapFromEntityToResponseDto() {
+        PassengerPayment entity = getPassengerPayment().build();
+
+        PassengerPaymentResponseDto actualResponseDto = passengerPaymentMapper.fromEntityToResponseDto(entity);
+        PassengerPaymentResponseDto expectedResponseDto = getPassengerPaymentResponseDto().build();
+
+        assertThat(actualResponseDto)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponseDto);
+    }
+
+    @Test
+    void shouldMapFromRequestDtoToEntity() {
+        PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+
+        PassengerPayment actualEntity = passengerPaymentMapper.fromRequestDtoToEntity(requestDto);
+        PassengerPayment expectedEntity = getPassengerPayment().build();
+
+        assertThat(actualEntity)
+                .usingRecursiveComparison()
+                .ignoringFields(FIELDS_TO_IGNORE)
+                .isEqualTo(expectedEntity);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentsFilterParamsMapperTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/mapper/PassengerPaymentsFilterParamsMapperTest.java
@@ -1,0 +1,42 @@
+package by.arvisit.cabapp.paymentservice.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentsFilterParams;
+import by.arvisit.cabapp.paymentservice.util.PaymentTestData;
+
+class PassengerPaymentsFilterParamsMapperTest {
+
+    private PassengerPaymentsFilterParamsMapper filterParamsMapper = new PassengerPaymentsFilterParamsMapper();
+
+    @Test
+    void shouldMapFromEmptyMapToFilterParamsDto() {
+        Map<String, String> mapParams = Collections.emptyMap();
+
+        PassengerPaymentsFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        PassengerPaymentsFilterParams expected = PaymentTestData.getEmptyPassengerPaymentsFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldMapFromFilledMapToFilterParamsDto() {
+        Map<String, String> mapParams = PaymentTestData.getPassengerPaymentsRequestParams();
+
+        PassengerPaymentsFilterParams result = filterParamsMapper.fromMapParams(mapParams);
+
+        PassengerPaymentsFilterParams expected = PaymentTestData.getFilledPassengerPaymentsFilterParams().build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentServiceImplTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentServiceImplTest.java
@@ -8,6 +8,7 @@ import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverAcc
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPayment;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentRequestDto;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getEmptyDriverPaymentsFilterParams;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,6 +38,7 @@ import by.arvisit.cabapp.paymentservice.dto.DriverAccountBalanceResponseDto;
 import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
 import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
 import by.arvisit.cabapp.paymentservice.mapper.DriverPaymentMapper;
+import by.arvisit.cabapp.paymentservice.mapper.DriverPaymentsFilterParamsMapper;
 import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
 import by.arvisit.cabapp.paymentservice.persistence.repository.DriverPaymentRepository;
 import by.arvisit.cabapp.paymentservice.persistence.util.DriverPaymentSpecs;
@@ -51,6 +53,8 @@ class DriverPaymentServiceImplTest {
     private DriverPaymentRepository driverPaymentRepository;
     @Mock
     private DriverPaymentMapper driverPaymentMapper;
+    @Mock
+    private DriverPaymentsFilterParamsMapper filterParamsMapper;
     @Mock
     private MessageSource messageSource;
     @Mock
@@ -117,6 +121,8 @@ class DriverPaymentServiceImplTest {
         Page<DriverPayment> driverPaymentsPage = new PageImpl<>(driverPayments);
         Specification<DriverPayment> spec = (root, query, cb) -> cb.conjunction();
 
+        when(filterParamsMapper.fromMapParams(any()))
+                .thenReturn(getEmptyDriverPaymentsFilterParams().build());
         when(driverPaymentSpecs.getAllByFilter(any()))
                 .thenReturn(spec);
         when(driverPaymentRepository.findAll(spec, pageable))

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentServiceImplTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentServiceImplTest.java
@@ -1,0 +1,153 @@
+package by.arvisit.cabapp.paymentservice.service.impl;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_ACCOUNT_BALANCE_ENOUGH;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverAccountBalanceResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPayment;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getDriverPaymentResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverAccountBalanceResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.mapper.DriverPaymentMapper;
+import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
+import by.arvisit.cabapp.paymentservice.persistence.repository.DriverPaymentRepository;
+import by.arvisit.cabapp.paymentservice.persistence.util.DriverPaymentSpecs;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DriverPaymentServiceImplTest {
+
+    @InjectMocks
+    private DriverPaymentServiceImpl driverPaymentService;
+    @Mock
+    private DriverPaymentRepository driverPaymentRepository;
+    @Mock
+    private DriverPaymentMapper driverPaymentMapper;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private DriverPaymentVerifier driverPaymentVerifier;
+    @Mock
+    private DriverPaymentSpecs driverPaymentSpecs;
+
+    @Test
+    void shouldReturnDriverResponseDto_whenSaveWithValidInput() {
+        DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+        DriverPayment payment = getDriverPayment().build();
+
+        when(driverPaymentMapper.fromRequestDtoToEntity(any(DriverPaymentRequestDto.class)))
+                .thenReturn(payment);
+        doNothing().when(driverPaymentVerifier)
+                .verifyNewPayment(any(DriverPayment.class));
+        when(driverPaymentRepository.save(any(DriverPayment.class)))
+                .thenReturn(payment);
+        when(driverPaymentMapper.fromEntityToResponseDto(any(DriverPayment.class)))
+                .thenReturn(responseDto);
+
+        DriverPaymentRequestDto requestDto = getDriverPaymentRequestDto().build();
+        DriverPaymentResponseDto result = driverPaymentService.save(requestDto);
+
+        assertThat(result)
+                .isEqualTo(responseDto);
+    }
+
+    @Test
+    void shouldReturnDriverResponseDto_whenGetPaymentByIdForExistingId() {
+        DriverPaymentResponseDto responseDto = getDriverPaymentResponseDto().build();
+        DriverPayment payment = getDriverPayment().build();
+
+        when(driverPaymentRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(payment));
+        when(driverPaymentMapper.fromEntityToResponseDto(any(DriverPayment.class)))
+                .thenReturn(responseDto);
+
+        DriverPaymentResponseDto result = driverPaymentService.getPaymentById(PASSENGER_PAYMENT_ID_STRING);
+
+        assertThat(result)
+                .isEqualTo(responseDto);
+
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetPaymentByIdForNonExistingId() {
+        when(driverPaymentRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> driverPaymentService.getPaymentById(PASSENGER_PAYMENT_ID_STRING))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnContainerWithDriverPaymentResponseDto_whenGetPayments() {
+
+        DriverPaymentResponseDto driverPaymentResponseDto = getDriverPaymentResponseDto()
+                .build();
+        DriverPayment driverPayment = getDriverPayment().build();
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        List<DriverPayment> driverPayments = List.of(driverPayment);
+        Page<DriverPayment> driverPaymentsPage = new PageImpl<>(driverPayments);
+        Specification<DriverPayment> spec = (root, query, cb) -> cb.conjunction();
+
+        when(driverPaymentSpecs.getAllByFilter(any()))
+                .thenReturn(spec);
+        when(driverPaymentRepository.findAll(spec, pageable))
+                .thenReturn(driverPaymentsPage);
+        when(driverPaymentMapper.fromEntityToResponseDto(any(DriverPayment.class)))
+                .thenReturn(driverPaymentResponseDto);
+        when(driverPaymentRepository.count(spec))
+                .thenReturn((long) driverPayments.size());
+
+        ListContainerResponseDto<DriverPaymentResponseDto> result = driverPaymentService.getPayments(pageable,
+                Collections.emptyMap());
+        ListContainerResponseDto<DriverPaymentResponseDto> expected = getListContainerForResponse(
+                DriverPaymentResponseDto.class)
+                .withValues(List.of(driverPaymentResponseDto))
+                .build();
+
+        assertThat(result)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnDriverAccountBalanceResponseDto_whenGetDriverAccountBalance() {
+        BigDecimal balance = DRIVER_ACCOUNT_BALANCE_ENOUGH;
+
+        when(driverPaymentRepository.getDriverAccountBalance(any(UUID.class)))
+                .thenReturn(balance);
+
+        DriverAccountBalanceResponseDto expected = getDriverAccountBalanceResponseDto().build();
+        DriverAccountBalanceResponseDto result = driverPaymentService.getDriverAccountBalance(DRIVER_ID_STRING);
+
+        assertThat(result)
+                .isEqualTo(expected);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentVerifierTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/DriverPaymentVerifierTest.java
@@ -1,0 +1,136 @@
+package by.arvisit.cabapp.paymentservice.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+
+import by.arvisit.cabapp.common.dto.driver.DriverResponseDto;
+import by.arvisit.cabapp.paymentservice.client.DriverClient;
+import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
+import by.arvisit.cabapp.paymentservice.persistence.model.OperationTypeEnum;
+import by.arvisit.cabapp.paymentservice.persistence.repository.DriverPaymentRepository;
+import by.arvisit.cabapp.paymentservice.util.PaymentTestData;
+
+@ExtendWith(MockitoExtension.class)
+class DriverPaymentVerifierTest {
+
+    @InjectMocks
+    private DriverPaymentVerifier driverPaymentVerifier;
+    @Mock
+    private DriverPaymentRepository driverPaymentRepository;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private DriverClient driverClient;
+
+    @Test
+    void shouldThrowNoException_whenVerifyNewPaymentWithValidPayment() {
+        DriverPaymentVerifier verifierSpy = Mockito.spy(driverPaymentVerifier);
+
+        doNothing().when(verifierSpy)
+                .verifyDriverForNewPayment(Mockito.any(DriverPayment.class));
+        doNothing().when(verifierSpy)
+                .verifyBalanceForNewPayment(Mockito.any(DriverPayment.class));
+
+        DriverPayment payment = PaymentTestData.getDriverPayment().build();
+
+        assertThatNoException().isThrownBy(() -> verifierSpy.verifyNewPayment(payment));
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyBalanceForNewPaymentWithRepayment() {
+        BigDecimal balance = PaymentTestData.DRIVER_ACCOUNT_BALANCE_ENOUGH;
+
+        when(driverPaymentRepository.getDriverAccountBalance(Mockito.any(UUID.class)))
+                .thenReturn(balance);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment()
+                .withOperation(OperationTypeEnum.REPAYMENT)
+                .build();
+
+        assertThatNoException().isThrownBy(() -> driverPaymentVerifier.verifyBalanceForNewPayment(payment));
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyBalanceForNewPaymentWithPositiveBalanceAndFitAmount() {
+        BigDecimal balance = PaymentTestData.DRIVER_ACCOUNT_BALANCE_ENOUGH;
+
+        when(driverPaymentRepository.getDriverAccountBalance(Mockito.any(UUID.class)))
+                .thenReturn(balance);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment()
+                .withOperation(OperationTypeEnum.WITHDRAWAL)
+                .build();
+
+        assertThatNoException().isThrownBy(() -> driverPaymentVerifier.verifyBalanceForNewPayment(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyBalanceForNewPaymentWithNegativeBalance() {
+        BigDecimal balance = PaymentTestData.DRIVER_ACCOUNT_BALANCE_NEGATIVE;
+
+        when(driverPaymentRepository.getDriverAccountBalance(Mockito.any(UUID.class)))
+                .thenReturn(balance);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment()
+                .withOperation(OperationTypeEnum.WITHDRAWAL)
+                .build();
+
+        assertThatThrownBy(() -> driverPaymentVerifier.verifyBalanceForNewPayment(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyBalanceForNewPaymentWithPositiveBalanceAndNotFitAmount() {
+        BigDecimal balance = PaymentTestData.DRIVER_ACCOUNT_BALANCE_NOT_ENOUGH;
+
+        when(driverPaymentRepository.getDriverAccountBalance(Mockito.any(UUID.class)))
+                .thenReturn(balance);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment()
+                .withOperation(OperationTypeEnum.WITHDRAWAL)
+                .build();
+
+        assertThatThrownBy(() -> driverPaymentVerifier.verifyBalanceForNewPayment(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyDriverForNewPaymentWithValidDriver() {
+        DriverResponseDto driver = PaymentTestData.getDriverResponseDto().build();
+
+        when(driverClient.getDriverById(Mockito.anyString()))
+                .thenReturn(driver);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment().build();
+
+        assertThatNoException().isThrownBy(() -> driverPaymentVerifier.verifyDriverForNewPayment(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyDriverForNewPaymentWithNoMatchForCardNumber() {
+        DriverResponseDto driver = PaymentTestData.getDriverResponseDto().build();
+
+        when(driverClient.getDriverById(Mockito.anyString()))
+                .thenReturn(driver);
+
+        DriverPayment payment = PaymentTestData.getDriverPayment()
+                .withCardNumber(PaymentTestData.PASSENGER_CARD_NUMBER)
+                .build();
+
+        assertThatThrownBy(() -> driverPaymentVerifier.verifyDriverForNewPayment(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImplTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImplTest.java
@@ -1,0 +1,137 @@
+package by.arvisit.cabapp.paymentservice.service.impl;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DEFAULT_PAGEABLE_SIZE;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPayment;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentRequestDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentResponseDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.mapper.PassengerPaymentMapper;
+import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
+import by.arvisit.cabapp.paymentservice.persistence.repository.PassengerPaymentRepository;
+import by.arvisit.cabapp.paymentservice.persistence.util.PassengerPaymentSpecs;
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class PassengerPaymentServiceImplTest {
+
+    @InjectMocks
+    private PassengerPaymentServiceImpl passengerPaymentService;
+    @Mock
+    private PassengerPaymentRepository passengerPaymentRepository;
+    @Mock
+    private PassengerPaymentMapper passengerPaymentMapper;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private PassengerPaymentVerifier passengerPaymentVerifier;
+    @Mock
+    private StreamBridge streamBridge;
+    @Mock
+    private PassengerPaymentSpecs passengerPaymentSpecs;
+
+    @Test
+    void shouldReturnPassengerResponseDto_whenSaveWithValidInput() {
+        PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+        PassengerPayment payment = getPassengerPayment().build();
+
+        when(passengerPaymentMapper.fromRequestDtoToEntity(any(PassengerPaymentRequestDto.class)))
+                .thenReturn(payment);
+        doNothing().when(passengerPaymentVerifier)
+                .verifyNewPayment(any(PassengerPayment.class));
+        when(passengerPaymentRepository.save(any(PassengerPayment.class)))
+                .thenReturn(payment);
+        when(passengerPaymentMapper.fromEntityToResponseDto(any(PassengerPayment.class)))
+                .thenReturn(responseDto);
+
+        PassengerPaymentRequestDto requestDto = getPassengerPaymentRequestDto().build();
+        PassengerPaymentResponseDto result = passengerPaymentService.save(requestDto);
+
+        assertThat(result)
+                .isEqualTo(responseDto);
+    }
+
+    @Test
+    void shouldReturnPassengerResponseDto_whenGetPaymentByIdForExistingId() {
+        PassengerPaymentResponseDto responseDto = getPassengerPaymentResponseDto().build();
+        PassengerPayment payment = getPassengerPayment().build();
+
+        when(passengerPaymentRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.of(payment));
+        when(passengerPaymentMapper.fromEntityToResponseDto(any(PassengerPayment.class)))
+                .thenReturn(responseDto);
+
+        PassengerPaymentResponseDto result = passengerPaymentService.getPaymentById(PASSENGER_PAYMENT_ID_STRING);
+
+        assertThat(result)
+                .isEqualTo(responseDto);
+
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenGetPaymentByIdForNonExistingId() {
+        when(passengerPaymentRepository.findById(any(UUID.class)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> passengerPaymentService.getPaymentById(PASSENGER_PAYMENT_ID_STRING))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void shouldReturnContainerWithPassengerPaymentResponseDto_whenGetPayments() {
+
+        PassengerPaymentResponseDto passengerPaymentResponseDto = getPassengerPaymentResponseDto()
+                .build();
+        PassengerPayment passengerPayment = getPassengerPayment().build();
+
+        Pageable pageable = Pageable.ofSize(DEFAULT_PAGEABLE_SIZE);
+        List<PassengerPayment> passengerPayments = List.of(passengerPayment);
+        Page<PassengerPayment> passengerPaymentsPage = new PageImpl<>(passengerPayments);
+        Specification<PassengerPayment> spec = (root, query, cb) -> cb.conjunction();
+
+        when(passengerPaymentSpecs.getAllByFilter(any()))
+                .thenReturn(spec);
+        when(passengerPaymentRepository.findAll(spec, pageable))
+                .thenReturn(passengerPaymentsPage);
+        when(passengerPaymentMapper.fromEntityToResponseDto(any(PassengerPayment.class)))
+                .thenReturn(passengerPaymentResponseDto);
+        when(passengerPaymentRepository.count(spec))
+                .thenReturn((long) passengerPayments.size());
+
+        ListContainerResponseDto<PassengerPaymentResponseDto> result = passengerPaymentService.getPayments(pageable,
+                Collections.emptyMap());
+        ListContainerResponseDto<PassengerPaymentResponseDto> expected = getListContainerForResponse(
+                PassengerPaymentResponseDto.class)
+                .withValues(List.of(passengerPaymentResponseDto))
+                .build();
+
+        assertThat(result)
+                .isEqualTo(expected);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImplTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentServiceImplTest.java
@@ -2,6 +2,7 @@ package by.arvisit.cabapp.paymentservice.service.impl;
 
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DEFAULT_PAGEABLE_SIZE;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_PAYMENT_ID_STRING;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getEmptyPassengerPaymentsFilterParams;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getListContainerForResponse;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPayment;
 import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPaymentRequestDto;
@@ -33,6 +34,7 @@ import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
 import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
 import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
 import by.arvisit.cabapp.paymentservice.mapper.PassengerPaymentMapper;
+import by.arvisit.cabapp.paymentservice.mapper.PassengerPaymentsFilterParamsMapper;
 import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
 import by.arvisit.cabapp.paymentservice.persistence.repository.PassengerPaymentRepository;
 import by.arvisit.cabapp.paymentservice.persistence.util.PassengerPaymentSpecs;
@@ -47,6 +49,8 @@ class PassengerPaymentServiceImplTest {
     private PassengerPaymentRepository passengerPaymentRepository;
     @Mock
     private PassengerPaymentMapper passengerPaymentMapper;
+    @Mock
+    private PassengerPaymentsFilterParamsMapper filterParamsMapper;
     @Mock
     private MessageSource messageSource;
     @Mock
@@ -115,6 +119,8 @@ class PassengerPaymentServiceImplTest {
         Page<PassengerPayment> passengerPaymentsPage = new PageImpl<>(passengerPayments);
         Specification<PassengerPayment> spec = (root, query, cb) -> cb.conjunction();
 
+        when(filterParamsMapper.fromMapParams(any()))
+                .thenReturn(getEmptyPassengerPaymentsFilterParams().build());
         when(passengerPaymentSpecs.getAllByFilter(any()))
                 .thenReturn(spec);
         when(passengerPaymentRepository.findAll(spec, pageable))

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentVerifierTest.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/service/impl/PassengerPaymentVerifierTest.java
@@ -1,0 +1,340 @@
+package by.arvisit.cabapp.paymentservice.service.impl;
+
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.ANOTHER_DRIVER_ID_UUID;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.ANOTHER_PASSENGER_ID_UUID;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_CARD_NUMBER;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.DRIVER_PAYMENT_AMOUNT;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.PASSENGER_CARD_NUMBER;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getEndedRideResponseDto;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerPayment;
+import static by.arvisit.cabapp.paymentservice.util.PaymentTestData.getPassengerResponseDto;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+
+import by.arvisit.cabapp.common.dto.passenger.PassengerResponseDto;
+import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
+import by.arvisit.cabapp.paymentservice.client.PassengerClient;
+import by.arvisit.cabapp.paymentservice.client.RideClient;
+import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
+import by.arvisit.cabapp.paymentservice.persistence.model.PaymentMethodEnum;
+import by.arvisit.cabapp.paymentservice.persistence.repository.PassengerPaymentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PassengerPaymentVerifierTest {
+
+    @InjectMocks
+    private PassengerPaymentVerifier passengerPaymentVerifier;
+    @Mock
+    private PassengerPaymentRepository passengerPaymentRepository;
+    @Mock
+    private MessageSource messageSource;
+    @Mock
+    private PassengerClient passengerClient;
+    @Mock
+    private RideClient rideClient;
+
+    @Test
+    void shouldThrowNoException_whenVerifyNewPaymentWithValidPayment() {
+        PassengerPaymentVerifier verifierSpy = spy(passengerPaymentVerifier);
+
+        doNothing().when(verifierSpy)
+                .verifyNewPaymentParametersCombination(any(PassengerPayment.class));
+        doNothing().when(verifierSpy)
+                .verifyIfSameSuccessfulPaymentExists(any(PassengerPayment.class));
+        doNothing().when(verifierSpy)
+                .verifyPassenger(any(PassengerPayment.class));
+        doNothing().when(verifierSpy)
+                .verifyRide(any(PassengerPayment.class));
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatNoException().isThrownBy(() -> verifierSpy.verifyNewPayment(payment));
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyNewPaymentParametersCombinationWithNoPaymentsForCurrentRide() {
+        List<PassengerPayment> paymentsForCurrentRide = Collections.emptyList();
+
+        when(passengerPaymentRepository.findByRideId(any(UUID.class)))
+                .thenReturn(paymentsForCurrentRide);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyNewPaymentParametersCombination(payment));
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyNewPaymentParametersCombinationWithSamePassengerAndDriverForCurrentRide() {
+        PassengerPayment payment = getPassengerPayment().build();
+        List<PassengerPayment> paymentsForCurrentRide = List.of(payment);
+
+        when(passengerPaymentRepository.findByRideId(any(UUID.class)))
+                .thenReturn(paymentsForCurrentRide);
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyNewPaymentParametersCombination(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyNewPaymentParametersCombinationWithDifferentPassengerForCurrentRide() {
+        PassengerPayment currentRidePayment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .build();
+        List<PassengerPayment> paymentsForCurrentRide = List.of(currentRidePayment);
+
+        when(passengerPaymentRepository.findByRideId(any(UUID.class)))
+                .thenReturn(paymentsForCurrentRide);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyNewPaymentParametersCombination(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyNewPaymentParametersCombinationWithDifferentDriverForCurrentRide() {
+        PassengerPayment currentRidePayment = getPassengerPayment()
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .build();
+        List<PassengerPayment> paymentsForCurrentRide = List.of(currentRidePayment);
+
+        when(passengerPaymentRepository.findByRideId(any(UUID.class)))
+                .thenReturn(paymentsForCurrentRide);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyNewPaymentParametersCombination(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyNewPaymentParametersCombinationWithDifferentPassengerAndDriverForCurrentRide() {
+        PassengerPayment currentRidePayment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .build();
+        List<PassengerPayment> paymentsForCurrentRide = List.of(currentRidePayment);
+
+        when(passengerPaymentRepository.findByRideId(any(UUID.class)))
+                .thenReturn(paymentsForCurrentRide);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyNewPaymentParametersCombination(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyIfSameSuccessfulPaymentExistsWithNoExistingSuccessfulPayment() {
+        when(passengerPaymentRepository.existsSuccessfulPayment(any(UUID.class), any(UUID.class), any(UUID.class)))
+                .thenReturn(false);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyIfSameSuccessfulPaymentExists(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyIfSameSuccessfulPaymentExistsWithExistingSuccessfulPayment() {
+        when(passengerPaymentRepository.existsSuccessfulPayment(any(UUID.class), any(UUID.class), any(UUID.class)))
+                .thenReturn(true);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyIfSameSuccessfulPaymentExists(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyPassengerWithCashPaymentMethod() {
+        PassengerResponseDto passenger = getPassengerResponseDto().build();
+
+        when(passengerClient.getPassengerById(anyString()))
+                .thenReturn(passenger);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPaymentMethod(PaymentMethodEnum.CASH)
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyPassenger(payment));
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyPassengerWithBankCardPaymentMethodAndSamePassengerCardNumber() {
+        String cardNumber = PASSENGER_CARD_NUMBER;
+        PassengerResponseDto passenger = getPassengerResponseDto()
+                .withCardNumber(cardNumber)
+                .build();
+
+        when(passengerClient.getPassengerById(anyString()))
+                .thenReturn(passenger);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD)
+                .withCardNumber(cardNumber)
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyPassenger(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyPassengerWithBankCardPaymentMethodAndDifferentPassengerCardNumber() {
+        PassengerResponseDto passenger = getPassengerResponseDto()
+                .withCardNumber(PASSENGER_CARD_NUMBER)
+                .build();
+
+        when(passengerClient.getPassengerById(anyString()))
+                .thenReturn(passenger);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD)
+                .withCardNumber(DRIVER_CARD_NUMBER)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyPassenger(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowNoException_whenVerifyRideWithMatchForPassengerAndDriverAndAmount() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment().build();
+
+        assertThatNoException()
+                .isThrownBy(() -> passengerPaymentVerifier.verifyRide(payment));
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForPassengerAndDriverAndAmount() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForPassenger() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForDriver() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForAmount() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForPassengerAndAmount() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForPassengerAndDriver() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withPassengerId(ANOTHER_PASSENGER_ID_UUID)
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_whenVerifyRideWithNoMatchForDriverAndAmount() {
+        RideResponseDto ride = getEndedRideResponseDto().build();
+
+        when(rideClient.getRideById(anyString()))
+                .thenReturn(ride);
+
+        PassengerPayment payment = getPassengerPayment()
+                .withDriverId(ANOTHER_DRIVER_ID_UUID)
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .build();
+
+        assertThatThrownBy(() -> passengerPaymentVerifier.verifyRide(payment))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/util/PaymentTestData.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/util/PaymentTestData.java
@@ -5,6 +5,8 @@ import static by.arvisit.cabapp.common.util.CommonConstants.EUROPE_MINSK_TIMEZON
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -12,11 +14,14 @@ import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
 import by.arvisit.cabapp.common.dto.driver.DriverResponseDto;
 import by.arvisit.cabapp.common.dto.passenger.PassengerResponseDto;
 import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
+import by.arvisit.cabapp.common.util.DateRange;
 import by.arvisit.cabapp.paymentservice.dto.DriverAccountBalanceResponseDto;
 import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
 import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentsFilterParams;
 import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
 import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentsFilterParams;
 import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
 import by.arvisit.cabapp.paymentservice.persistence.model.OperationTypeEnum;
 import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
@@ -79,6 +84,13 @@ public final class PaymentTestData {
     public static final String DRIVER_ID_REQUEST_PARAM = "driverId";
     public static final String PASSENGER_ID_REQUEST_PARAM = "passengerId";
     public static final String TIMESTAMP_REQUEST_PARAM = "timestamp";
+    public static final String RIDE_ID_REQUEST_PARAM = "rideId";
+    public static final String STATUS_REQUEST_PARAM = "status";
+    public static final String PAYMENT_METHOD_REQUEST_PARAM = "paymentMethod";
+    public static final String OPERATION_REQUEST_PARAM = "operation";
+
+    public static final String DATE_REQUEST_VALUE = "2024-01-02";
+    public static final DateRange DATE_RANGE_FROM_REQUEST = DateRange.fromSingleValue(DATE_REQUEST_VALUE);
 
     private PaymentTestData() {
     }
@@ -206,6 +218,62 @@ public final class PaymentTestData {
                 .withSize(DEFAULT_PAGEABLE_SIZE)
                 .withLastPage(0)
                 .withSort(UNSORTED);
+    }
+
+    public static PassengerPaymentsFilterParams.PassengerPaymentsFilterParamsBuilder getEmptyPassengerPaymentsFilterParams() {
+        return PassengerPaymentsFilterParams.builder()
+                .withStatus(null)
+                .withPaymentMethod(null)
+                .withPassengerId(null)
+                .withDriverId(null)
+                .withRideId(null)
+                .withTimestamp(null);
+    }
+
+    public static PassengerPaymentsFilterParams.PassengerPaymentsFilterParamsBuilder getFilledPassengerPaymentsFilterParams() {
+        return PassengerPaymentsFilterParams.builder()
+                .withStatus(PaymentStatusEnum.SUCCESS.toString())
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                .withPassengerId(PASSENGER_ID_UUID)
+                .withDriverId(DRIVER_ID_UUID)
+                .withRideId(RIDE_ID_UUID)
+                .withTimestamp(DATE_RANGE_FROM_REQUEST);
+    }
+
+    public static Map<String, String> getPassengerPaymentsRequestParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put(STATUS_REQUEST_PARAM, PaymentStatusEnum.SUCCESS.toString());
+        params.put(PAYMENT_METHOD_REQUEST_PARAM, PaymentMethodEnum.BANK_CARD.toString());
+        params.put(PASSENGER_ID_REQUEST_PARAM, PASSENGER_ID_STRING);
+        params.put(DRIVER_ID_REQUEST_PARAM, DRIVER_ID_STRING);
+        params.put(RIDE_ID_REQUEST_PARAM, RIDE_ID_STRING);
+        params.put(TIMESTAMP_REQUEST_PARAM, DATE_REQUEST_VALUE);
+        return params;
+    }
+
+    public static DriverPaymentsFilterParams.DriverPaymentsFilterParamsBuilder getEmptyDriverPaymentsFilterParams() {
+        return DriverPaymentsFilterParams.builder()
+                .withStatus(null)
+                .withOperation(null)
+                .withDriverId(null)
+                .withTimestamp(null);
+    }
+
+    public static DriverPaymentsFilterParams.DriverPaymentsFilterParamsBuilder getFilledDriverPaymentsFilterParams() {
+        return DriverPaymentsFilterParams.builder()
+                .withStatus(PaymentStatusEnum.SUCCESS.toString())
+                .withOperation(OperationTypeEnum.WITHDRAWAL.toString())
+                .withDriverId(DRIVER_ID_UUID)
+                .withTimestamp(DATE_RANGE_FROM_REQUEST);
+    }
+
+    public static Map<String, String> getDriverPaymentsRequestParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put(STATUS_REQUEST_PARAM, PaymentStatusEnum.SUCCESS.toString());
+        params.put(OPERATION_REQUEST_PARAM, OperationTypeEnum.WITHDRAWAL.toString());
+        params.put(DRIVER_ID_REQUEST_PARAM, DRIVER_ID_STRING);
+        params.put(TIMESTAMP_REQUEST_PARAM, DATE_REQUEST_VALUE);
+        return params;
     }
 
     public static Stream<String> blankStrings() {

--- a/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/util/PaymentTestData.java
+++ b/cab-app-payment-service/src/test/java/by/arvisit/cabapp/paymentservice/util/PaymentTestData.java
@@ -1,0 +1,229 @@
+package by.arvisit.cabapp.paymentservice.util;
+
+import static by.arvisit.cabapp.common.util.CommonConstants.EUROPE_MINSK_TIMEZONE;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import by.arvisit.cabapp.common.dto.ListContainerResponseDto;
+import by.arvisit.cabapp.common.dto.driver.DriverResponseDto;
+import by.arvisit.cabapp.common.dto.passenger.PassengerResponseDto;
+import by.arvisit.cabapp.common.dto.rides.RideResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverAccountBalanceResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.DriverPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentRequestDto;
+import by.arvisit.cabapp.paymentservice.dto.PassengerPaymentResponseDto;
+import by.arvisit.cabapp.paymentservice.persistence.model.DriverPayment;
+import by.arvisit.cabapp.paymentservice.persistence.model.OperationTypeEnum;
+import by.arvisit.cabapp.paymentservice.persistence.model.PassengerPayment;
+import by.arvisit.cabapp.paymentservice.persistence.model.PaymentMethodEnum;
+import by.arvisit.cabapp.paymentservice.persistence.model.PaymentStatusEnum;
+
+public final class PaymentTestData {
+
+    public static final BigDecimal DRIVER_ACCOUNT_BALANCE_ENOUGH = BigDecimal.valueOf(1000);
+    public static final BigDecimal DRIVER_ACCOUNT_BALANCE_NOT_ENOUGH = BigDecimal.valueOf(10);
+    public static final BigDecimal DRIVER_ACCOUNT_BALANCE_NEGATIVE = BigDecimal.valueOf(-10);
+    public static final String DRIVER_PAYMENT_ID_STRING = "23904afd-a2af-4e04-a605-b2d375ab8ca4";
+    public static final UUID DRIVER_PAYMENT_ID_UUID = UUID.fromString(DRIVER_PAYMENT_ID_STRING);
+    public static final String DRIVER_CARD_NUMBER = "1522613953683617";
+    public static final BigDecimal DRIVER_PAYMENT_AMOUNT = BigDecimal.valueOf(50);
+    public static final String PASSENGER_PAYMENT_ID_STRING = "cce748fb-1a3a-468e-a49e-08a26fe2a418";
+    public static final UUID PASSENGER_PAYMENT_ID_UUID = UUID.fromString(PASSENGER_PAYMENT_ID_STRING);
+    public static final BigDecimal PASSENGER_PAYMENT_FEE_AMOUNT = BigDecimal.valueOf(5);
+    public static final BigDecimal PASSENGER_PAYMENT_AMOUNT = BigDecimal.valueOf(100);
+    public static final BigDecimal PASSENGER_PAYMENT_NEGATIVE_AMOUNT = BigDecimal.valueOf(-100);
+    public static final String PASSENGER_CARD_NUMBER = "7853471929691513";
+    public static final String PASSENGER_EMAIL = "vivienne.gutierrez@yahoo.com.ar";
+    public static final String PASSENGER_NAME = "Vivienne Gutierrez";
+    public static final String DRIVER_ID_STRING = "a7dd0543-0adc-4ea6-9ca7-7b72065ca011";
+    public static final String DRIVER_NAME = "Jeremias Olsen";
+    public static final String DRIVER_EMAIL = "jeremias.olsen@frontiernet.net";
+    public static final String ANOTHER_DRIVER_ID_STRING = "a7cd0543-0adc-4ea6-9ca7-7b72065ca011";
+    public static final UUID ANOTHER_DRIVER_ID_UUID = UUID.fromString(ANOTHER_DRIVER_ID_STRING);
+    public static final UUID DRIVER_ID_UUID = UUID.fromString(DRIVER_ID_STRING);
+    public static final String PASSENGER_ID_STRING = "3abcc6a1-94da-4185-aaa1-8a11c1b8efd2";
+    public static final String ANOTHER_PASSENGER_ID_STRING = "3abdc6a1-94da-4185-aaa1-8a11c1b8efd2";
+    public static final UUID ANOTHER_PASSENGER_ID_UUID = UUID.fromString(ANOTHER_PASSENGER_ID_STRING);;
+    public static final UUID PASSENGER_ID_UUID = UUID.fromString(PASSENGER_ID_STRING);
+    public static final String RIDE_ID_STRING = "a5b0a1f9-f45d-4287-bbad-ea6253976d0d";
+    public static final UUID RIDE_ID_UUID = UUID.fromString(RIDE_ID_STRING);
+    public static final String RIDE_DESTINATION_ADDRESS = "Llewellyn Street, 35";
+    public static final String RIDE_START_ADDRESS = "Bramcote Grove, 42";
+    public static final BigDecimal RIDE_INITIAL_COST = BigDecimal.valueOf(100);
+    public static final BigDecimal RIDE_FINAL_COST = BigDecimal.valueOf(100);
+    public static final ZonedDateTime PASSENGER_PAYMENT_DEFAULT_TIMESTAMP = ZonedDateTime.of(2024, 4, 4, 12, 0, 0, 0,
+            EUROPE_MINSK_TIMEZONE);
+    public static final ZonedDateTime DRIVER_PAYMENT_DEFAULT_TIMESTAMP = ZonedDateTime.of(2024, 4, 4, 12, 1, 0, 0,
+            EUROPE_MINSK_TIMEZONE);
+    public static final ZonedDateTime DEFAULT_TIMESTAMP = ZonedDateTime.of(2024, 4, 4, 12, 2, 0, 0,
+            EUROPE_MINSK_TIMEZONE);
+    public static final int DEFAULT_PAGEABLE_SIZE = 10;
+    public static final String UNSORTED = "UNSORTED";
+    public static final String ENCODING_UTF_8 = "UTF-8";
+    public static final String NOT_VALID_OPERATION = "DEBT";
+    public static final String NOT_VALID_PAYMENT_METHOD = "DIAMONDS";
+    public static final String URL_DRIVER_PAYMENTS = "/api/v1/driver-payments";
+    public static final String URL_DRIVER_PAYMENTS_ID_TEMPLATE = "/api/v1/driver-payments/{id}";
+    public static final String URL_DRIVER_PAYMENTS_PARAM_VALUE_TEMPLATE = "/api/v1/driver-payments?{param}={value}";
+    public static final String URL_DRIVER_PAYMENTS_DRIVERS_ID_BALANCE_TEMPLATE = "/api/v1/driver-payments/drivers/{id}/balance";
+    public static final String URL_PASSENGER_PAYMENTS = "/api/v1/passenger-payments";
+    public static final String URL_PASSENGER_PAYMENTS_ID_TEMPLATE = "/api/v1/passenger-payments/{id}";
+    public static final String URL_PASSENGER_PAYMENTS_PARAM_VALUE_TEMPLATE = "/api/v1/passenger-payments?{param}={value}";
+    
+    public static final String NOT_ALLOWED_REQUEST_PARAM = "noSuchParam";
+    public static final String DRIVER_ID_REQUEST_PARAM = "driverId";
+    public static final String PASSENGER_ID_REQUEST_PARAM = "passengerId";
+    public static final String TIMESTAMP_REQUEST_PARAM = "timestamp";
+
+    private PaymentTestData() {
+    }
+
+    public static PassengerPaymentRequestDto.PassengerPaymentRequestDtoBuilder getPassengerPaymentRequestDto() {
+        return PassengerPaymentRequestDto.builder()
+                .withRideId(RIDE_ID_STRING)
+                .withPassengerId(PASSENGER_ID_STRING)
+                .withDriverId(DRIVER_ID_STRING)
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                .withCardNumber(PASSENGER_CARD_NUMBER)
+                .withAmount(PASSENGER_PAYMENT_AMOUNT);
+    }
+
+    public static PassengerPayment.PassengerPaymentBuilder getPassengerPayment() {
+        return PassengerPayment.builder()
+                .withId(PASSENGER_PAYMENT_ID_UUID)
+                .withRideId(RIDE_ID_UUID)
+                .withPassengerId(PASSENGER_ID_UUID)
+                .withDriverId(DRIVER_ID_UUID)
+                .withAmount(PASSENGER_PAYMENT_AMOUNT)
+                .withFeeAmount(PASSENGER_PAYMENT_FEE_AMOUNT)
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD)
+                .withCardNumber(PASSENGER_CARD_NUMBER)
+                .withStatus(PaymentStatusEnum.SUCCESS)
+                .withTimestamp(PASSENGER_PAYMENT_DEFAULT_TIMESTAMP);
+    }
+
+    public static PassengerPaymentResponseDto.PassengerPaymentResponseDtoBuilder getPassengerPaymentResponseDto() {
+        return PassengerPaymentResponseDto.builder()
+                .withId(PASSENGER_PAYMENT_ID_STRING)
+                .withRideId(RIDE_ID_STRING)
+                .withPassengerId(PASSENGER_ID_STRING)
+                .withDriverId(DRIVER_ID_STRING)
+                .withAmount(PASSENGER_PAYMENT_AMOUNT)
+                .withFeeAmount(PASSENGER_PAYMENT_FEE_AMOUNT)
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                .withCardNumber(PASSENGER_CARD_NUMBER)
+                .withStatus(PaymentStatusEnum.SUCCESS.toString())
+                .withTimestamp(PASSENGER_PAYMENT_DEFAULT_TIMESTAMP);
+    }
+
+    public static DriverPaymentRequestDto.DriverPaymentRequestDtoBuilder getDriverPaymentRequestDto() {
+        return DriverPaymentRequestDto.builder()
+                .withDriverId(DRIVER_ID_STRING)
+                .withOperation(OperationTypeEnum.WITHDRAWAL.toString())
+                .withCardNumber(DRIVER_CARD_NUMBER)
+                .withAmount(DRIVER_PAYMENT_AMOUNT);
+    }
+
+    public static DriverPayment.DriverPaymentBuilder getDriverPayment() {
+        return DriverPayment.builder()
+                .withId(DRIVER_PAYMENT_ID_UUID)
+                .withDriverId(DRIVER_ID_UUID)
+                .withOperation(OperationTypeEnum.WITHDRAWAL)
+                .withCardNumber(DRIVER_CARD_NUMBER)
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .withStatus(PaymentStatusEnum.SUCCESS)
+                .withTimestamp(DRIVER_PAYMENT_DEFAULT_TIMESTAMP);
+    }
+
+    public static DriverPaymentResponseDto.DriverPaymentResponseDtoBuilder getDriverPaymentResponseDto() {
+        return DriverPaymentResponseDto.builder()
+                .withId(DRIVER_PAYMENT_ID_STRING)
+                .withDriverId(DRIVER_ID_STRING)
+                .withOperation(OperationTypeEnum.WITHDRAWAL.toString())
+                .withCardNumber(DRIVER_CARD_NUMBER)
+                .withAmount(DRIVER_PAYMENT_AMOUNT)
+                .withStatus(PaymentStatusEnum.SUCCESS.toString())
+                .withTimestamp(DRIVER_PAYMENT_DEFAULT_TIMESTAMP);
+    }
+
+    public static DriverAccountBalanceResponseDto.DriverAccountBalanceResponseDtoBuilder getDriverAccountBalanceResponseDto() {
+        return DriverAccountBalanceResponseDto.builder()
+                .withDriverId(DRIVER_ID_STRING)
+                .withBalance(DRIVER_ACCOUNT_BALANCE_ENOUGH);
+    }
+
+    public static PassengerResponseDto.PassengerResponseDtoBuilder getPassengerResponseDto() {
+        return PassengerResponseDto.builder()
+                .withId(PASSENGER_ID_STRING)
+                .withName(PASSENGER_NAME)
+                .withEmail(PASSENGER_EMAIL)
+                .withCardNumber(PASSENGER_CARD_NUMBER);
+    }
+    
+    public static RideResponseDto.RideResponseDtoBuilder getEndedRideResponseDto() {
+        return RideResponseDto.builder()
+                .withId(RIDE_ID_STRING)
+                .withPassengerId(PASSENGER_ID_STRING)
+                .withDriverId(DRIVER_ID_STRING)
+                .withPaymentMethod(PaymentMethodEnum.BANK_CARD.toString())
+                .withStartAddress(RIDE_START_ADDRESS)
+                .withDestinationAddress(RIDE_DESTINATION_ADDRESS)
+                .withInitialCost(RIDE_INITIAL_COST)
+                .withFinalCost(RIDE_FINAL_COST)
+                .withIsPaid(false)
+                .withStatus("END_RIDE")
+                .withPromoCode(null)
+                .withPassengerScore(null)
+                .withDriverScore(null)
+                .withBookRide(DEFAULT_TIMESTAMP)
+                .withCancelRide(null)
+                .withAcceptRide(DEFAULT_TIMESTAMP)
+                .withBeginRide(DEFAULT_TIMESTAMP)
+                .withEndRide(DEFAULT_TIMESTAMP)
+                .withFinishRide(null);
+    }
+    
+    public static DriverResponseDto.DriverResponseDtoBuilder getDriverResponseDto() {
+        return DriverResponseDto.builder()
+                .withId(DRIVER_ID_STRING)
+                .withName(DRIVER_NAME)
+                .withEmail(DRIVER_EMAIL)
+                .withCardNumber(DRIVER_CARD_NUMBER)
+                .withCar(null)
+                .withIsAvailable(true);
+    }
+
+    public static <T> ListContainerResponseDto.ListContainerResponseDtoBuilder<T> getListContainerForResponse(
+            Class<T> clazz) {
+        return ListContainerResponseDto.<T>builder()
+                .withValues(Collections.emptyList())
+                .withCurrentPage(0)
+                .withSize(DEFAULT_PAGEABLE_SIZE)
+                .withLastPage(0)
+                .withSort(UNSORTED);
+    }
+
+    public static Stream<String> blankStrings() {
+        return Stream.of("", "   ", null);
+    }
+
+    public static Stream<String> malformedUUIDs() {
+        return Stream.of("3abcc6a1-94da-4185-1-8a11c1b8efd2", "3abcc6a1-94da-4185-aaa1-8a11c1b8efdw",
+                "3ABCC6A1-94DA-4185-AAA1-8A11C1B8EFD2", "   ", "1234", "abc", "111122223333444a",
+                "111122223333-444");
+    }
+
+    public static Stream<String> malformedDates() {
+        return Stream.of("", "   ", "abc", "111122223333444a", "111122223333-444", "truth", "lies", "trui",
+                "falce", "232", "2004-18", "23-121", "2004-12-88", "2004-11-11T25", "2004-11-11 11");
+    }
+
+    public static Stream<String> malformedCardNumbers() {
+        return Stream.of("", "   ", "1234", "abc", "111122223333444a", "111122223333-444");
+    }
+}


### PR DESCRIPTION
- **Add test data for unit tests**
- **Enable direct feign clients for dev, itest profiles**
- **Correct date field type in DriverPaymentResponseDto**
- **Add feeAmount field to ignored for mapping from request dto**
- **Add unit tests for mappers**
- **Add unit tests for service layer**
- **Add WebMvcTests for controllers**
- **Correct message according to controller update**
- **Add test data for filter params**
- **Add filter params mapper tests**
- **Correct expected messages**
- **Add new filter params handling**
